### PR TITLE
Enable running the template with the CLI

### DIFF
--- a/remix.config.js
+++ b/remix.config.js
@@ -1,8 +1,15 @@
+// Replace the HOST env var with SHOPIFY_APP_URL so that it doesn't break the remix server. The CLI will eventually
+// stop passing in HOST, so we can remove this workaround after the next major release.
+if (process.env.HOST) {
+  process.env.SHOPIFY_APP_URL = process.env.HOST;
+  delete process.env.HOST;
+}
+
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
-  ignoredRouteFiles: ['**/.*'],
-  appDirectory: 'app',
+  ignoredRouteFiles: ["**/.*"],
+  appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/"
-}
+};


### PR DESCRIPTION
Currently, the CLI sets the `HOST` env var for our existing templates, which remix also uses. The problem is that they expect different formats, so the remix dev server fails to start. Luckily, the CLI will already be deprecating `HOST` in any case, so the problem will eventually solve itself.

This PR addresses that by using the future name of the env var (`SHOPIFY_APP_URL`) so that the template won't break when moving over to the next major version.