### PR TITLE
Make package.json compatible with buildpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "deploy": "shopify app deploy",
     "env": "shopify app env",
     "db:up": "npx prisma db push",
-    "db:setup": "prisma generate",
+    "db:generate": "prisma generate",
     "start": "remix-serve build"
   },
   "dependencies": {


### PR DESCRIPTION
Add changes to make template compatible with Paketo buildpacks.

In general, buildpacks do on build:

- install node
- install yarn (as there is a yarn.lock)
- run `yarn install`
- run `yarn build`

On runtime, the default entrypoint will run `yarn start`.

---

`NODE_ENV=production` is required due remix issue remix-run/remix#4081

Once that issue is solved, we should be able to remove the NODE_ENV setting from here.