### PR TITLE
Use id token not session token

### DIFF
--- a/shopify-app-remix/src/oauth/strategy.ts
+++ b/shopify-app-remix/src/oauth/strategy.ts
@@ -23,7 +23,7 @@ interface SessionContext {
   token?: JwtPayload;
 }
 
-const SESSION_TOKEN_ARG = "id_token";
+const SESSION_TOKEN_PARAM = "id_token";
 
 export class AuthStrategy<
   Config extends AppConfigArg,
@@ -238,7 +238,7 @@ export class AuthStrategy<
     const url = new URL(request.url);
 
     const shop = url.searchParams.get("shop")!;
-    const searchParamSessionToken = url.searchParams.get(SESSION_TOKEN_ARG);
+    const searchParamSessionToken = url.searchParams.get(SESSION_TOKEN_PARAM);
 
     if (api.config.isEmbeddedApp && !searchParamSessionToken) {
       logger.debug(
@@ -254,7 +254,7 @@ export class AuthStrategy<
     const url = new URL(request.url);
 
     const shop = url.searchParams.get("shop")!;
-    const searchParamSessionToken = url.searchParams.get(SESSION_TOKEN_ARG)!;
+    const searchParamSessionToken = url.searchParams.get(SESSION_TOKEN_PARAM)!;
 
     if (api.config.isEmbeddedApp) {
       logger.debug(


### PR DESCRIPTION
With https://github.com/Shopify/shopify/pull/426945 shipping we need to update the Remix package to get the session token from the id_token param.  

I've updated the name of the URL param, but internally we still refer to it as an id_token.  Short term I think this makes sense. More medium/long term we probably want to update the API package, and the remix package.  But that's abigger change than I think we should take on no.w