### PR TITLE
Add todo to revisit response format

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -62,6 +62,10 @@ export async function action({ request }: ActionArgs) {
   );
 
   const result = await admin.rest.get({ path: "/products/count.json" });
+
+  // TODO: Returning the parsed body as a string/object might be confusing for Remix users. We should consider returning
+  // the body as a stream, or renaming it to something that indicates it's a string.
+  // https://github.com/Shopify/shopify-app-template-remix/issues/55
   return json(result.body);
 }
 


### PR DESCRIPTION
As pointed out by the team, we should consider whether we should return something that matches the web API response format for rest / gql requests, instead of returning the parsed body as an object.

We could consider a global library config that changes the response body to be a ReadableStream instead of an object.