### PR TITLE
Ensure appUrl has a port for localhost

### DIFF
--- a/remix.config.js
+++ b/remix.config.js
@@ -7,12 +7,7 @@ if (
   (!process.env.SHOPIFY_APP_URL ||
     process.env.SHOPIFY_APP_URL === process.env.HOST)
 ) {
-  const url = new URL(process.env.HOST);
-  if (url.hostname === "localhost") {
-    url.port = process.env.PORT;
-  }
-
-  process.env.SHOPIFY_APP_URL = url.origin;
+  process.env.SHOPIFY_APP_URL = process.env.HOST;
   delete process.env.HOST;
 }
 

--- a/shopify-app-remix/package-lock.json
+++ b/shopify-app-remix/package-lock.json
@@ -1030,7 +1030,7 @@
     "node_modules/@shopify/shopify-api": {
       "version": "7.1.0",
       "resolved": "file:../../shopify-api-js/shopify-shopify-api-7.1.0.tgz",
-      "integrity": "sha512-Ahvv4r0qhwMIxAXDqG7v2UBKpbiXqAaeKQM2MXI3wlFFv7f54CIq58mYKC6DS5iaTL88XrDUEP+/DP9u2N8r3A==",
+      "integrity": "sha512-5gWabQYqun5iKIXpCv2Z6oGe+6eKaHHVm4bTP9p4Sh9voGVO4BiBlamcRfeeOaLCNF2UWd73CeZ6lF/IlxCuaA==",
       "license": "MIT",
       "dependencies": {
         "@shopify/network": "^3.2.1",

--- a/shopify-app-remix/src/index.ts
+++ b/shopify-app-remix/src/index.ts
@@ -65,9 +65,11 @@ export function shopifyApp<
 function deriveApi<Resources extends ShopifyRestResources>(
   appConfig: AppConfigArg
 ): Shopify<Resources> {
-  // TODO: Make sure the port is being added in the CLI when filling SHOPIFY_APP_URL
-  // https://github.com/orgs/Shopify/projects/6899/views/1?pane=issue&itemId=28356136
   const appUrl = new URL(appConfig.appUrl);
+  if (appUrl.hostname === "localhost" && !appUrl.port && process.env.PORT) {
+    appUrl.port = process.env.PORT;
+  }
+  appConfig.appUrl = appUrl.origin;
 
   let userAgentPrefix = `Shopify Remix Library v${SHOPIFY_REMIX_LIBRARY_VERSION}`;
   if (appConfig.userAgentPrefix) {


### PR DESCRIPTION
The CLI might not include the port in the `HOST` and `SHOPIFY_APP_URL` env vars when running on localhost, but we'll need it to create references to the app during development.

This PR does that.