### PR TITLE
Add GraphQL query to reinstall flow

### DIFF
--- a/shopify-app-remix/src/auth/merchant/authenticate.ts
+++ b/shopify-app-remix/src/auth/merchant/authenticate.ts
@@ -226,7 +226,7 @@ export class AuthStrategy<
         await this.testSession(offlineSession);
       } catch (error) {
         if (error instanceof HttpResponseError && error.response.code === 401) {
-          logger.info("Shop hasn't installed app yet, redirecting to OAuth", {
+          logger.info("Shop session is no longer valid, redirecting to OAuth", {
             shop,
           });
           throw await beginAuth({ api, config, logger }, request, false, shop);


### PR DESCRIPTION
Closes https://github.com/Shopify/shopify-app-template-remix/issues/61

If the app is uninstalled and doesn't have an app_uninstalled webhook, we'll end up with leftover sessions in the database. This PR adds a GQL API query to check that the app is actually installed and functional before embedding itself.

This is a fairly rare scenario, it's most common for developers when they're testing uninstalling the app, or actual reinstalls, so it doesn't really affect performance.