### PR TITLE
Make REST overrides thread-safe

### DIFF
--- a/shopify-app-remix/src/auth/admin/authenticate.ts
+++ b/shopify-app-remix/src/auth/admin/authenticate.ts
@@ -479,7 +479,7 @@ export class AuthStrategy<
     const { api, config, logger } = this;
 
     const GraphqlClient = api.clients.Graphql;
-    const originalClient = new api.clients.Graphql({ session });
+    const originalClient = new GraphqlClient({ session });
     const originalQuery = Reflect.get(originalClient, "query");
 
     class RemixGraphqlClient extends GraphqlClient {


### PR DESCRIPTION
Closes #47 

I'm not entirely sure if the memory cost isn't too high here, but this is at least thread safe now. I pasted an analysis in the issue: https://github.com/Shopify/shopify-app-template-remix/issues/47#issuecomment-1559985463