### PR TITLE
Test session token page response

### DIFF
--- a/shopify-app-remix/src/auth/admin/__tests__/patchSessionTokenPath.test.ts
+++ b/shopify-app-remix/src/auth/admin/__tests__/patchSessionTokenPath.test.ts
@@ -2,7 +2,7 @@ import { shopifyApp } from "../../..";
 import { getThrownResponse, testConfig } from "../../../__tests__/test-helper";
 
 describe("authorize.admin", () => {
-  test("Uses AppBridge to get a session token if the URL is for session-token page", async () => {
+  test("Uses AppBridge to get a session token if the URL is for auth.patchSessionTokenPath", async () => {
     // GIVEN
     const config = testConfig();
     const shopify = shopifyApp(config);
@@ -24,7 +24,7 @@ describe("authorize.admin", () => {
     );
   });
 
-  test("Uses AppBridge to get a session token if the URL is for configured session-token page", async () => {
+  test("Uses AppBridge to get a session token if the URL is for auth.patchSessionTokenPath and authPathPrefix is configured", async () => {
     // GIVEN
     const authPathPrefix = "/shopify";
     const config = testConfig({ authPathPrefix });

--- a/shopify-app-remix/src/auth/admin/authenticate.ts
+++ b/shopify-app-remix/src/auth/admin/authenticate.ts
@@ -56,7 +56,8 @@ export class AuthStrategy<
 
     const url = new URL(request.url);
 
-    const isBouncePage = url.pathname === config.auth.sessionTokenPath;
+    const isPatchSessionToken =
+      url.pathname === config.auth.patchSessionTokenPath;
     const isExitIframe = url.pathname === config.auth.exitIframePath;
     const isAuthRequest = url.pathname === config.auth.path;
     const isAuthCallbackRequest = url.pathname === config.auth.callbackPath;
@@ -65,7 +66,7 @@ export class AuthStrategy<
     logger.info("Authenticating admin request");
 
     let sessionContext: SessionContext;
-    if (isBouncePage) {
+    if (isPatchSessionToken) {
       logger.debug("Rendering bounce page");
       this.renderAppBridge();
     } else if (isExitIframe) {
@@ -404,7 +405,7 @@ export class AuthStrategy<
 
     // TODO Make sure this works on chrome without a tunnel (weird HTTPS redirect issue)
     // https://github.com/orgs/Shopify/projects/6899/views/1?pane=issue&itemId=28376650
-    throw redirect(`${config.auth.sessionTokenPath}?${params.toString()}`);
+    throw redirect(`${config.auth.patchSessionTokenPath}?${params.toString()}`);
   }
 
   private renderAppBridge(redirectTo?: string): never {

--- a/shopify-app-remix/src/config-types.ts
+++ b/shopify-app-remix/src/config-types.ts
@@ -41,7 +41,7 @@ interface AuthConfig {
   path: string;
   callbackPath: string;
   exitIframePath: string;
-  sessionTokenPath: string;
+  patchSessionTokenPath: string;
 }
 
 // TODO: The callbackUrl field should be optional (and eventually removed) in the library

--- a/shopify-app-remix/src/index.ts
+++ b/shopify-app-remix/src/index.ts
@@ -116,7 +116,7 @@ function deriveConfig<Storage extends SessionStorage>(
     auth: {
       path: authPathPrefix,
       callbackPath: authPathPrefix + "/callback",
-      sessionTokenPath: authPathPrefix + "/session-token",
+      patchSessionTokenPath: authPathPrefix + "/session-token",
       exitIframePath: authPathPrefix + "/auth/exit-iframe",
     },
   };


### PR DESCRIPTION
1. [Add tests for when the URL is the bounce page URL](https://github.com/Shopify/shopify-app-template-remix/commit/d9d0ea349d294659a5cafc88cd8057589998aa99)
2. [Rename path to be more explicit](https://github.com/Shopify/shopify-app-template-remix/commit/b83e6683914c8ab604c7fc2ad89b863893ed2639).  Here I saw that we sometimes use session token page, and other times we use bounce page.  I thought bounce page wouldn't mean much to anyone 6 months for now, and the addition of patch made the name more explicit.