### PR TITLE
Refactor request mock function

### DIFF
--- a/shopify-app-remix/src/__tests__/request-mock.test.ts
+++ b/shopify-app-remix/src/__tests__/request-mock.test.ts
@@ -12,16 +12,13 @@ describe("Request mocks", () => {
 
   it("can intercept fetch requests", async () => {
     // GIVEN
-    mockExternalRequest({
-      request: {
-        url: "https://my-example.shopify.io",
-        method: "GET",
+    await mockExternalRequest({
+      request: new Request("https://my-example.shopify.io", {
         headers: { bar: "baz" },
-      },
-      response: {
-        body: { responseFoo: "responseBar" },
-        init: { status: 200 },
-      },
+      }),
+      response: new Response(JSON.stringify({ responseFoo: "responseBar" }), {
+        status: 200,
+      }),
     });
 
     // WHEN
@@ -31,29 +28,21 @@ describe("Request mocks", () => {
     });
 
     // THEN
-    validateMocks();
+    await validateMocks();
   });
 
   it("can intercept multiple requests", async () => {
     // GIVEN
-    mockExternalRequests(
+    await mockExternalRequests(
       {
-        request: {
-          url: "https://my-example.shopify.io",
-          method: "GET",
-        },
-        response: {
-          init: { status: 200 },
-        },
+        request: new Request("https://my-example.shopify.io"),
+        response: new Response(),
       },
       {
-        request: {
-          url: "https://my-example.shopify.io",
+        request: new Request("https://my-example.shopify.io", {
           method: "POST",
-        },
-        response: {
-          init: { status: 200 },
-        },
+        }),
+        response: new Response(),
       }
     );
 
@@ -62,29 +51,21 @@ describe("Request mocks", () => {
     await fetch("https://my-example.shopify.io", { method: "POST" });
 
     // THEN
-    validateMocks();
+    await validateMocks();
   });
 
   it("detects failures after the first request", async () => {
     // GIVEN
-    mockExternalRequests(
+    await mockExternalRequests(
       {
-        request: {
-          url: "https://my-example.shopify.io",
-          method: "GET",
-        },
-        response: {
-          init: { status: 200 },
-        },
+        request: new Request("https://my-example.shopify.io"),
+        response: new Response(),
       },
       {
-        request: {
-          url: "https://my-example.shopify.io",
+        request: new Request("https://my-example.shopify.io", {
           method: "POST",
-        },
-        response: {
-          init: { status: 200 },
-        },
+        }),
+        response: new Response(),
       }
     );
 
@@ -93,18 +74,15 @@ describe("Request mocks", () => {
     await fetch("https://my-example.shopify.io", { method: "GET" });
 
     // THEN
-    expect(() => validateMocks()).toThrow(
+    await expect(validateMocks()).rejects.toThrow(
       "GET request made to https://my-example.shopify.io does not match expectation"
     );
   });
 
   it("matches responses automatically when no request mock is configured", async () => {
     // GIVEN
-    mockExternalRequest({
-      response: {
-        body: { responseFoo: "responseBar" },
-        init: { status: 200 },
-      },
+    await mockExternalRequest({
+      response: new Response(JSON.stringify({ responseFoo: "responseBar" })),
     });
 
     // WHEN
@@ -115,26 +93,22 @@ describe("Request mocks", () => {
     });
 
     // THEN
-    validateMocks();
+    await validateMocks();
   });
 
   ["url", "method", "body", "headers"].forEach((field) => {
     it(`can match requests without ${field}`, async () => {
       // GIVEN
-      const request = {
-        url: "https://my-example.shopify.io",
+      const request = new Request("https://my-example.shopify.io", {
         method: "POST",
-        body: { foo: "bar" },
+        body: JSON.stringify({ foo: "bar" }),
         headers: { bar: "baz" },
-      };
+      });
 
       delete (request as any)[field];
-      mockExternalRequest({
+      await mockExternalRequest({
         request,
-        response: {
-          body: { responseFoo: "responseBar" },
-          init: { status: 200 },
-        },
+        response: new Response(JSON.stringify({ responseFoo: "responseBar" })),
       });
 
       // WHEN
@@ -145,27 +119,23 @@ describe("Request mocks", () => {
       });
 
       // THEN
-      validateMocks();
+      await validateMocks();
     });
   });
 
   it("throws if an expected request isn't made", async () => {
     // GIVEN
-    mockExternalRequest({
-      request: {
-        url: "https://my-example.shopify.io",
+    await mockExternalRequest({
+      request: new Request("https://my-example.shopify.io", {
         method: "POST",
-        body: { foo: "bar" },
+        body: JSON.stringify({ foo: "bar" }),
         headers: { bar: "baz" },
-      },
-      response: {
-        body: { responseFoo: "responseBar" },
-        init: { status: 200 },
-      },
+      }),
+      response: new Response(JSON.stringify({ responseFoo: "responseBar" })),
     });
 
     // THEN
-    expect(() => validateMocks()).toThrow(
+    await expect(validateMocks()).rejects.toThrow(
       "Expected 1 request(s) to be made but they were not"
     );
   });
@@ -179,6 +149,8 @@ describe("Request mocks", () => {
     });
 
     // THEN
-    expect(() => validateMocks()).toThrow("1 unexpected request(s) were made");
+    await expect(validateMocks()).rejects.toThrow(
+      "1 unexpected request(s) were made"
+    );
   });
 });

--- a/shopify-app-remix/src/__tests__/test-helper.ts
+++ b/shopify-app-remix/src/__tests__/test-helper.ts
@@ -33,6 +33,7 @@ export function testConfig(
 export const SHOPIFY_HOST = "totally-real-host.myshopify.io";
 export const BASE64_HOST = Buffer.from(SHOPIFY_HOST).toString("base64");
 export const TEST_SHOP = "test-shop.myshopify.io";
+export const GRAPHQL_URL = `https://${TEST_SHOP}/admin/api/${LATEST_API_VERSION}/graphql.json`;
 
 interface TestJwt {
   token: string;

--- a/shopify-app-remix/src/auth/webhooks/__tests__/register.test.ts
+++ b/shopify-app-remix/src/auth/webhooks/__tests__/register.test.ts
@@ -1,7 +1,11 @@
 import { Session } from "@shopify/shopify-api";
 
 import { DeliveryMethod, shopifyApp } from "../../..";
-import { TEST_SHOP, testConfig } from "../../../__tests__/test-helper";
+import {
+  GRAPHQL_URL,
+  TEST_SHOP,
+  testConfig,
+} from "../../../__tests__/test-helper";
 
 import * as mockResponses from "./mock-responses";
 import { mockExternalRequests } from "../../../__tests__/request-mock";
@@ -27,14 +31,24 @@ describe("Webhook registration", () => {
       accessToken: "totally_real_token",
     });
 
-    mockExternalRequests(
+    await mockExternalRequests(
       {
-        request: { body: expect.stringContaining("webhookSubscriptions") },
-        response: { body: mockResponses.EMPTY_WEBHOOK_RESPONSE },
+        request: new Request(GRAPHQL_URL, {
+          method: "POST",
+          body: "webhookSubscriptions",
+        }),
+        response: new Response(
+          JSON.stringify(mockResponses.EMPTY_WEBHOOK_RESPONSE)
+        ),
       },
       {
-        request: { body: expect.stringContaining("webhookSubscriptionCreate") },
-        response: { body: mockResponses.HTTP_WEBHOOK_CREATE_RESPONSE },
+        request: new Request(GRAPHQL_URL, {
+          method: "POST",
+          body: "webhookSubscriptionCreate",
+        }),
+        response: new Response(
+          JSON.stringify(mockResponses.HTTP_WEBHOOK_CREATE_RESPONSE)
+        ),
       }
     );
 
@@ -67,14 +81,26 @@ describe("Webhook registration", () => {
       accessToken: "totally_real_token",
     });
 
-    mockExternalRequests(
+    await mockExternalRequests(
       {
-        request: { body: expect.stringContaining("webhookSubscriptions") },
-        response: { body: mockResponses.EMPTY_WEBHOOK_RESPONSE },
+        request: new Request(GRAPHQL_URL, {
+          method: "POST",
+          body: "webhookSubscriptions",
+        }),
+        response: new Response(
+          JSON.stringify(mockResponses.EMPTY_WEBHOOK_RESPONSE)
+        ),
       },
       {
-        request: { body: expect.stringContaining("webhookSubscriptionCreate") },
-        response: { body: mockResponses.HTTP_WEBHOOK_CREATE_ERROR_RESPONSE },
+        request: new Request(GRAPHQL_URL, {
+          method: "POST",
+          body: "webhookSubscriptionCreate",
+        }),
+        response: new Response(
+          JSON.stringify({
+            body: mockResponses.HTTP_WEBHOOK_CREATE_ERROR_RESPONSE,
+          })
+        ),
       }
     );
 


### PR DESCRIPTION
Instead of using objects that _mock_ requests and objects, we could just use `Request` and `Response` objects for setting up our mocks.