### PR TITLE
Oops

### DIFF
--- a/shopify-app-remix/src/__tests__/request-mock.test.ts
+++ b/shopify-app-remix/src/__tests__/request-mock.test.ts
@@ -96,6 +96,20 @@ describe("Request mocks", () => {
     await validateMocks();
   });
 
+  it("can mock non-200 responses", async () => {
+    // GIVEN
+    await mockExternalRequest({
+      request: new Request("https://my-example.shopify.io"),
+      response: new Response(undefined, { status: 500 }),
+    });
+
+    // WHEN
+    await fetch("https://my-example.shopify.io");
+
+    // THEN
+    await validateMocks();
+  });
+
   ["url", "method", "body", "headers"].forEach((field) => {
     it(`can match requests without ${field}`, async () => {
       // GIVEN

--- a/shopify-app-remix/src/__tests__/request-mock.ts
+++ b/shopify-app-remix/src/__tests__/request-mock.ts
@@ -42,7 +42,9 @@ async function mockParams(response: Response): Promise<ResponseParams> {
   return {
     body: await response.text(),
     init: {
-      ...response,
+      status: response.status,
+      statusText: response.statusText,
+      url: response.url,
       headers: Object.fromEntries(response.headers.entries()),
     },
   };
@@ -75,7 +77,7 @@ export async function validateMocks() {
 
     if (request?.method) {
       expected.method = request.method;
-      actual.method = init?.method;
+      actual.method = init?.method || "GET";
     }
 
     if (request?.body) {

--- a/shopify-app-remix/src/__tests__/test-helper.ts
+++ b/shopify-app-remix/src/__tests__/test-helper.ts
@@ -5,7 +5,9 @@ import {
   LATEST_API_VERSION,
   JwtPayload,
   LogSeverity,
+  Session,
 } from "@shopify/shopify-api";
+import { SessionStorage } from "@shopify/shopify-app-session-storage";
 import { MemorySessionStorage } from "@shopify/shopify-app-session-storage-memory";
 
 import { AppConfigArg } from "../config-types";
@@ -13,7 +15,7 @@ import { AppConfigArg } from "../config-types";
 // eslint-disable-next-line import/no-mutable-exports
 export function testConfig(
   overrides: Partial<AppConfigArg> = {}
-): AppConfigArg {
+): AppConfigArg & { sessionStorage: SessionStorage } {
   return {
     apiKey: "testApiKey",
     apiSecretKey: "testApiSecretKey",
@@ -48,7 +50,7 @@ export function getJwt(
   const date = new Date();
   const payload = {
     iss: `${TEST_SHOP}/admin`,
-    dest: TEST_SHOP,
+    dest: `https://${TEST_SHOP}`,
     aud: apiKey,
     sub: "12345",
     exp: date.getTime() / 1000 + 3600,
@@ -87,6 +89,20 @@ export function createTestHmac(secretKey: string, body: string): string {
     .createHmac("sha256", secretKey)
     .update(body, "utf8")
     .digest("base64");
+}
+
+export async function setUpValidSession(sessionStorage: SessionStorage) {
+  const session = new Session({
+    id: `offline_${TEST_SHOP}`,
+    shop: TEST_SHOP,
+    isOnline: false,
+    state: "test",
+    accessToken: "totally_real_token",
+    scope: "testScope",
+  });
+  await sessionStorage.storeSession(session);
+
+  return session;
 }
 
 export function signRequestCookie({

--- a/shopify-app-remix/src/auth/admin/authenticate.ts
+++ b/shopify-app-remix/src/auth/admin/authenticate.ts
@@ -181,15 +181,18 @@ export class AuthStrategy<
     const { api } = this;
     const url = new URL(request.url);
 
-    const host = api.utils.sanitizeHost(url.searchParams.get("host")!);
-    if (!host) {
-      throw new Error("Host param is not present");
+    if (this.config.isEmbeddedApp) {
+      const host = api.utils.sanitizeHost(url.searchParams.get("host")!);
+      if (!host) {
+        throw new Error("Host search param is not present");
+      }
     }
 
+    // There's an assumption here that the shop search param will always be present. If it isn't, we'll throw an error
+    // but an alternative would be to show a page for the user to fill in the shop, like shopify_app does.
     const shop = api.utils.sanitizeShop(url.searchParams.get("shop")!);
-
     if (!shop) {
-      throw new Error("Shop param is not present");
+      throw new Error("Shop search param is not present");
     }
   }
 

--- a/shopify-app-remix/src/billing/__tests__/mock-responses.ts
+++ b/shopify-app-remix/src/billing/__tests__/mock-responses.ts
@@ -1,0 +1,48 @@
+export const PLAN_1 = "Shopify app plan 1";
+export const PLAN_2 = "Shopify app plan 2";
+export const ALL_PLANS = [PLAN_1, PLAN_2];
+
+export const CONFIRMATION_URL = "totally-real-url";
+
+export const EMPTY_SUBSCRIPTIONS = JSON.stringify({
+  data: {
+    currentAppInstallation: {
+      oneTimePurchases: {
+        edges: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+      activeSubscriptions: [],
+      userErrors: [],
+    },
+  },
+});
+
+export const EXISTING_SUBSCRIPTION = JSON.stringify({
+  data: {
+    currentAppInstallation: {
+      oneTimePurchases: {
+        edges: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+      activeSubscriptions: [{ name: PLAN_1, test: true }],
+    },
+  },
+});
+
+export const PURCHASE_SUBSCRIPTION_RESPONSE = JSON.stringify({
+  data: {
+    appSubscriptionCreate: {
+      confirmationUrl: CONFIRMATION_URL,
+      userErrors: [],
+    },
+  },
+});
+
+export const PURCHASE_SUBSCRIPTION_RESPONSE_WITH_USER_ERRORS = JSON.stringify({
+  data: {
+    appSubscriptionCreate: {
+      confirmationUrl: CONFIRMATION_URL,
+      userErrors: ["Oops, something went wrong"],
+    },
+  },
+});

--- a/shopify-app-remix/src/billing/__tests__/request.test.ts
+++ b/shopify-app-remix/src/billing/__tests__/request.test.ts
@@ -1,0 +1,346 @@
+import {
+  BillingError,
+  BillingInterval,
+  HttpResponseError,
+  SESSION_COOKIE_NAME,
+  Shopify,
+} from "@shopify/shopify-api";
+
+import { shopifyApp } from "../..";
+import {
+  BASE64_HOST,
+  GRAPHQL_URL,
+  TEST_SHOP,
+  getJwt,
+  getThrownResponse,
+  setUpValidSession,
+  signRequestCookie,
+  testConfig,
+} from "../../__tests__/test-helper";
+import {
+  mockExternalRequest,
+  mockExternalRequests,
+} from "../../__tests__/request-mock";
+
+import * as responses from "./mock-responses";
+
+const BILLING_CONFIG: Shopify["config"]["billing"] = {
+  [responses.PLAN_1]: {
+    amount: 5,
+    currencyCode: "USD",
+    interval: BillingInterval.Every30Days,
+  },
+};
+
+describe("Billing request", () => {
+  // TODO: This is currently blocked because the authenticator doesn't work properly with non-embedded apps
+  it("redirects to payment confirmation URL when successful and at the top level for non-embedded apps", async () => {
+    // GIVEN
+    const config = testConfig();
+    const session = await setUpValidSession(config.sessionStorage);
+    const shopify = shopifyApp({
+      ...config,
+      isEmbeddedApp: false,
+      billing: BILLING_CONFIG,
+    });
+
+    mockExternalRequests({
+      request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
+      response: new Response(responses.PURCHASE_SUBSCRIPTION_RESPONSE),
+    });
+
+    const request = new Request(
+      `${shopify.config.appUrl}/billing?shop=${TEST_SHOP}`
+    );
+    signRequestCookie({
+      request,
+      cookieName: SESSION_COOKIE_NAME,
+      cookieValue: session.id,
+      apiSecretKey: config.apiSecretKey,
+    });
+
+    const { billing } = await shopify.authenticate.admin(request);
+
+    // WHEN
+    const response = await getThrownResponse(
+      async () => billing.request({ plan: responses.PLAN_1, isTest: true }),
+      request
+    );
+
+    // THEN
+    expect(response.status).toEqual(302);
+    expect(response.headers.get("Location")).toEqual(
+      responses.CONFIRMATION_URL
+    );
+  });
+
+  it("redirects to exit-iframe with payment confirmation URL when successful using app bridge when embedded", async () => {
+    // GIVEN
+    const config = testConfig();
+    await setUpValidSession(config.sessionStorage);
+    const shopify = shopifyApp({ ...config, billing: BILLING_CONFIG });
+
+    mockExternalRequest({
+      request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
+      response: new Response(responses.PURCHASE_SUBSCRIPTION_RESPONSE),
+    });
+
+    const token = getJwt(
+      shopify.config.apiKey,
+      shopify.config.apiSecretKey
+    ).token;
+    const request = new Request(
+      `${shopify.config.appUrl}/billing?embedded=1&shop=${TEST_SHOP}&host=${BASE64_HOST}&id_token=${token}`
+    );
+
+    const { billing } = await shopify.authenticate.admin(request);
+
+    // WHEN
+    const response = await getThrownResponse(
+      async () => billing.request({ plan: responses.PLAN_1, isTest: true }),
+      request
+    );
+
+    // THEN
+    expect(response.status).toEqual(302);
+
+    const locationUrl = new URL(
+      response.headers.get("Location")!,
+      "http://test.test"
+    );
+    expect(locationUrl.pathname).toEqual(shopify.config.auth.exitIframePath);
+    expect(locationUrl.searchParams.get("shop")).toEqual(TEST_SHOP);
+    expect(locationUrl.searchParams.get("host")).toEqual(BASE64_HOST);
+    expect(locationUrl.searchParams.get("exitIframe")).toEqual(
+      responses.CONFIRMATION_URL
+    );
+  });
+
+  it("returns redirection headers when successful during fetch requests", async () => {
+    // GIVEN
+    const config = testConfig();
+    await setUpValidSession(config.sessionStorage);
+    const shopify = shopifyApp({ ...config, billing: BILLING_CONFIG });
+
+    mockExternalRequest({
+      request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
+      response: new Response(responses.PURCHASE_SUBSCRIPTION_RESPONSE),
+    });
+
+    const request = new Request(`${shopify.config.appUrl}/billing`, {
+      headers: {
+        Authorization: `Bearer ${
+          getJwt(shopify.config.apiKey, shopify.config.apiSecretKey).token
+        }`,
+      },
+    });
+
+    const { billing } = await shopify.authenticate.admin(request);
+
+    // WHEN
+    const response = await getThrownResponse(
+      async () => billing.request({ plan: responses.PLAN_1, isTest: true }),
+      request
+    );
+
+    // THEN
+    expect(response.status).toEqual(302);
+    expect(
+      response.headers.get("X-Shopify-API-Request-Failure-Reauthorize-Url")
+    ).toEqual(responses.CONFIRMATION_URL);
+  });
+
+  it("redirects to authentication when at the top level when Shopify invalidated the session", async () => {
+    // GIVEN
+    const config = testConfig();
+    const session = await setUpValidSession(config.sessionStorage);
+    const shopify = shopifyApp({
+      ...config,
+      isEmbeddedApp: false,
+      billing: BILLING_CONFIG,
+    });
+
+    mockExternalRequests({
+      request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
+      response: new Response(undefined, {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    });
+
+    const request = new Request(
+      `${shopify.config.appUrl}/billing?shop=${TEST_SHOP}`
+    );
+    signRequestCookie({
+      request,
+      cookieName: SESSION_COOKIE_NAME,
+      cookieValue: session.id,
+      apiSecretKey: config.apiSecretKey,
+    });
+
+    const { billing } = await shopify.authenticate.admin(request);
+
+    // WHEN
+    const response = await getThrownResponse(
+      async () => billing.request({ plan: responses.PLAN_1, isTest: true }),
+      request
+    );
+
+    // THEN
+    expect(response.status).toEqual(302);
+
+    const locationUrl = new URL(response.headers.get("Location")!);
+    expect(locationUrl.host).toEqual(TEST_SHOP);
+    expect(locationUrl.pathname).toEqual("/admin/oauth/authorize");
+  });
+
+  it("redirects to exit-iframe with authentication using app bridge when embedded and Shopify invalidated the session", async () => {
+    // GIVEN
+    const config = testConfig();
+    await setUpValidSession(config.sessionStorage);
+    const shopify = shopifyApp({ ...config, billing: BILLING_CONFIG });
+
+    mockExternalRequest({
+      request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
+      response: new Response(undefined, {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    });
+
+    const token = getJwt(
+      shopify.config.apiKey,
+      shopify.config.apiSecretKey
+    ).token;
+    const request = new Request(
+      `${shopify.config.appUrl}/billing?embedded=1&shop=${TEST_SHOP}&host=${BASE64_HOST}&id_token=${token}`
+    );
+
+    const { billing } = await shopify.authenticate.admin(request);
+
+    // WHEN
+    const response = await getThrownResponse(
+      async () => billing.request({ plan: responses.PLAN_1, isTest: true }),
+      request
+    );
+
+    // THEN
+    expect(response.status).toEqual(302);
+
+    const locationUrl = new URL(
+      response.headers.get("Location")!,
+      "http://test.test"
+    );
+    expect(locationUrl.pathname).toEqual(shopify.config.auth.exitIframePath);
+    expect(locationUrl.searchParams.get("shop")).toEqual(TEST_SHOP);
+    expect(locationUrl.searchParams.get("host")).toEqual(BASE64_HOST);
+    expect(locationUrl.searchParams.get("exitIframe")).toEqual(
+      `${shopify.config.auth.path}?shop=${TEST_SHOP}`
+    );
+  });
+
+  it("returns redirection headers during fetch requests when Shopify invalidated the session", async () => {
+    // GIVEN
+    const config = testConfig();
+    await setUpValidSession(config.sessionStorage);
+    const shopify = shopifyApp({ ...config, billing: BILLING_CONFIG });
+
+    mockExternalRequest({
+      request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
+      response: new Response(undefined, {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    });
+
+    const request = new Request(`${shopify.config.appUrl}/billing`, {
+      headers: {
+        Authorization: `Bearer ${
+          getJwt(shopify.config.apiKey, shopify.config.apiSecretKey).token
+        }`,
+      },
+    });
+
+    const { billing } = await shopify.authenticate.admin(request);
+
+    // WHEN
+    const response = await getThrownResponse(
+      async () => billing.request({ plan: responses.PLAN_1, isTest: true }),
+      request
+    );
+
+    // THEN
+    expect(response.status).toEqual(401);
+
+    const reauthUrl = new URL(
+      response.headers.get("X-Shopify-API-Request-Failure-Reauthorize-Url")!
+    );
+    expect(reauthUrl.origin).toEqual(shopify.config.appUrl);
+    expect(reauthUrl.pathname).toEqual(shopify.config.auth.path);
+  });
+
+  it("throws errors other than authentication errors", async () => {
+    // GIVEN
+    const config = testConfig();
+    const session = await setUpValidSession(config.sessionStorage);
+    const shopify = shopifyApp({
+      ...config,
+      isEmbeddedApp: false,
+      billing: BILLING_CONFIG,
+    });
+
+    mockExternalRequests({
+      request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
+      response: new Response(undefined, {
+        status: 500,
+        statusText: "Internal Server Error",
+      }),
+    });
+
+    const request = new Request(
+      `${shopify.config.appUrl}/billing?shop=${TEST_SHOP}`
+    );
+    signRequestCookie({
+      request,
+      cookieName: SESSION_COOKIE_NAME,
+      cookieValue: session.id,
+      apiSecretKey: config.apiSecretKey,
+    });
+
+    const { billing } = await shopify.authenticate.admin(request);
+
+    // THEN
+    await expect(
+      billing.request({ plan: responses.PLAN_1, isTest: true })
+    ).rejects.toThrowError(HttpResponseError);
+  });
+
+  it("throws a BillingError when the response contains user errors", async () => {
+    // GIVEN
+    const config = testConfig();
+    await setUpValidSession(config.sessionStorage);
+    const shopify = shopifyApp({ ...config, billing: BILLING_CONFIG });
+
+    mockExternalRequest({
+      request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
+      response: new Response(
+        responses.PURCHASE_SUBSCRIPTION_RESPONSE_WITH_USER_ERRORS
+      ),
+    });
+
+    const token = getJwt(
+      shopify.config.apiKey,
+      shopify.config.apiSecretKey
+    ).token;
+    const { billing } = await shopify.authenticate.admin(
+      new Request(
+        `${shopify.config.appUrl}/billing?embedded=1&shop=${TEST_SHOP}&host=${BASE64_HOST}&id_token=${token}`
+      )
+    );
+
+    // THEN
+    await expect(
+      billing.request({ plan: responses.PLAN_1, isTest: true })
+    ).rejects.toThrowError(BillingError);
+  });
+});

--- a/shopify-app-remix/src/billing/__tests__/require.test.ts
+++ b/shopify-app-remix/src/billing/__tests__/require.test.ts
@@ -1,0 +1,91 @@
+import { BillingInterval, Shopify } from "@shopify/shopify-api";
+
+import { shopifyApp } from "../..";
+import {
+  GRAPHQL_URL,
+  getJwt,
+  setUpValidSession,
+  testConfig,
+} from "../../__tests__/test-helper";
+import { mockExternalRequest } from "../../__tests__/request-mock";
+
+import * as responses from "./mock-responses";
+
+const BILLING_CONFIG: Shopify["config"]["billing"] = {
+  [responses.PLAN_1]: {
+    amount: 5,
+    currencyCode: "USD",
+    interval: BillingInterval.Every30Days,
+  },
+};
+
+describe("Billing require", () => {
+  it("throws the returned response from onFailure when there is no payment", async () => {
+    // GIVEN
+    const config = testConfig();
+    await setUpValidSession(config.sessionStorage);
+    const shopify = shopifyApp({ ...config, billing: BILLING_CONFIG });
+
+    mockExternalRequest({
+      request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
+      response: new Response(responses.EMPTY_SUBSCRIPTIONS),
+    });
+
+    const { billing } = await shopify.authenticate.admin(
+      new Request(`${shopify.config.appUrl}/billing`, {
+        headers: {
+          Authorization: `Bearer ${
+            getJwt(shopify.config.apiKey, shopify.config.apiSecretKey).token
+          }`,
+        },
+      })
+    );
+
+    // WHEN
+    try {
+      await billing.require({
+        plans: [responses.PLAN_1],
+        onFailure: async (error) => {
+          expect(error.message).toBe("Billing check failed");
+          return new Response("Test response", { status: 402 });
+        },
+      });
+    } catch (response) {
+      expect(response.status).toBe(402);
+      expect(await response.text()).toBe("Test response");
+    }
+  });
+
+  it("returns true when there is payment", async () => {
+    // GIVEN
+    const config = testConfig();
+    await setUpValidSession(config.sessionStorage);
+    const shopify = shopifyApp({ ...config, billing: BILLING_CONFIG });
+
+    mockExternalRequest({
+      request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
+      response: new Response(responses.EXISTING_SUBSCRIPTION),
+    });
+
+    const { billing } = await shopify.authenticate.admin(
+      new Request(`${shopify.config.appUrl}/billing`, {
+        headers: {
+          Authorization: `Bearer ${
+            getJwt(shopify.config.apiKey, shopify.config.apiSecretKey).token
+          }`,
+        },
+      })
+    );
+
+    // WHEN
+    const success = await billing.require({
+      plans: [responses.PLAN_1],
+      onFailure: async () => {
+        throw new Error("This should not be called");
+      },
+    });
+
+    // THEN
+    expect(success).toBe(true);
+  });
+});

--- a/shopify-app-remix/src/billing/request.ts
+++ b/shopify-app-remix/src/billing/request.ts
@@ -63,11 +63,11 @@ function redirectOutOfApp(
   // https://github.com/orgs/Shopify/projects/6899/views/1?pane=issue&itemId=28374220
   if (isXhrRequest) {
     // TODO Check this with the beta flag disabled (with the bounce page)
-    // Remix is not including the X-Shopify-API-Request-Failure-Reauthorize-Url when throwing a 401 Response
+    // Remix is not including the X-Shopify-API-Request-Failure-Reauthorize-Url when throwing a Response
     // https://github.com/remix-run/remix/issues/5356
     throw new Response(undefined, {
-      status: 401,
-      statusText: "Unauthorized",
+      status: 302,
+      statusText: "Redirect",
       headers: {
         "X-Shopify-API-Request-Failure-Reauthorize-Url": url,
       },
@@ -81,6 +81,7 @@ function redirectOutOfApp(
 
     return redirect(`${config.auth.exitIframePath}?${params.toString()}`);
   } else {
+    // This will only ever happen for non-embedded apps, because the authenticator will stop before reaching this point
     return redirect(url);
   }
 }

--- a/shopify-app-remix/src/billing/types.ts
+++ b/shopify-app-remix/src/billing/types.ts
@@ -3,7 +3,7 @@ import { AppConfigArg } from "../config-types";
 
 export interface RequireBillingOptions<Config extends AppConfigArg>
   extends Omit<BillingCheckParams, "session" | "plans"> {
-  onFailure: (error: any) => Promise<void>;
+  onFailure: (error: any) => Promise<Response>;
   plans: (keyof Config["billing"])[];
 }
 


### PR DESCRIPTION
Closes https://github.com/Shopify/shopify-app-template-remix/issues/72

This adds tests covering the following cases when billing for the app:

redirects to payment confirmation URL when successful and at the top level for non-embedded apps
This is currently skipped due to https://github.com/Shopify/shopify-app-template-remix/issues/88
redirects to exit-iframe with payment confirmation URL when successful using app bridge when embedded
returns redirection headers when successful during fetch requests
redirects to authentication when at the top level when Shopify invalidated the session
redirects to exit-iframe with authentication using app bridge when embedded and Shopify invalidated the session
returns redirection headers during fetch requests when Shopify invalidated the session
throws errors other than authentication errors
throws a BillingError when the response contains user errors