### PR TITLE
Expose billing.cancel method

### DIFF
--- a/shopify-app-remix/src/auth/admin/__tests__/auth-callback-path.test.ts
+++ b/shopify-app-remix/src/auth/admin/__tests__/auth-callback-path.test.ts
@@ -136,7 +136,7 @@ describe("authorize.admin auth callback path", () => {
       });
 
       // WHEN
-      mockCodeExchangeRequest("offline");
+      await mockCodeExchangeRequest("offline");
       const response = await getThrownResponse(
         shopify.authenticate.admin,
         await getValidCallbackRequest(config)
@@ -154,7 +154,7 @@ describe("authorize.admin auth callback path", () => {
       const shopify = shopifyApp(config);
 
       // WHEN
-      mockCodeExchangeRequest("offline");
+      await mockCodeExchangeRequest("offline");
       await getThrownResponse(
         shopify.authenticate.admin,
         await getValidCallbackRequest(config)
@@ -181,7 +181,7 @@ describe("authorize.admin auth callback path", () => {
       const shopify = shopifyApp(config);
 
       // WHEN
-      mockCodeExchangeRequest("offline");
+      await mockCodeExchangeRequest("offline");
       const response = await getThrownResponse(
         shopify.authenticate.admin,
         await getValidCallbackRequest(config)
@@ -206,7 +206,7 @@ describe("authorize.admin auth callback path", () => {
       const shopify = shopifyApp(config);
 
       // WHEN
-      mockCodeExchangeRequest("online");
+      await mockCodeExchangeRequest("online");
       const response = await getThrownResponse(
         shopify.authenticate.admin,
         await getValidCallbackRequest(config)
@@ -228,7 +228,7 @@ describe("authorize.admin auth callback path", () => {
       const shopify = shopifyApp(config);
 
       // WHEN
-      mockCodeExchangeRequest();
+      await mockCodeExchangeRequest();
       await getThrownResponse(
         shopify.authenticate.admin,
         await getValidCallbackRequest(config)
@@ -244,7 +244,7 @@ describe("authorize.admin auth callback path", () => {
       const shopify = shopifyApp(config);
 
       // WHEN
-      mockCodeExchangeRequest("offline");
+      await mockCodeExchangeRequest("offline");
       const response = await getThrownResponse(
         shopify.authenticate.admin,
         await getValidCallbackRequest(config)
@@ -265,7 +265,7 @@ describe("authorize.admin auth callback path", () => {
       const shopify = shopifyApp(config);
 
       // WHEN
-      mockCodeExchangeRequest("offline");
+      await mockCodeExchangeRequest("offline");
       const request = await getValidCallbackRequest(config);
       const response = await getThrownResponse(
         shopify.authenticate.admin,
@@ -319,13 +319,15 @@ async function getValidCallbackRequest(config: ReturnType<typeof testConfig>) {
   return request;
 }
 
-function mockCodeExchangeRequest(tokenType: "online" | "offline" = "offline") {
+async function mockCodeExchangeRequest(
+  tokenType: "online" | "offline" = "offline"
+) {
   const responseBody = {
     access_token: "123abc",
     scope: "read_products",
   };
 
-  mockExternalRequest({
+  await mockExternalRequest({
     request: new Request(`https://${TEST_SHOP}/admin/oauth/access_token`, {
       method: "POST",
     }),

--- a/shopify-app-remix/src/auth/admin/authenticate.ts
+++ b/shopify-app-remix/src/auth/admin/authenticate.ts
@@ -16,7 +16,11 @@ import {
 import { BasicParams } from "../../types";
 import { AdminApiContext, AppConfig, AppConfigArg } from "../../config-types";
 import { BillingContext } from "../../billing/types";
-import { requestBillingFactory, requireBillingFactory } from "../../billing";
+import {
+  cancelBillingFactory,
+  requestBillingFactory,
+  requireBillingFactory,
+} from "../../billing";
 
 import { AdminContext } from "./types";
 import {
@@ -571,6 +575,7 @@ export class AuthStrategy<
     return {
       require: requireBillingFactory({ api, logger, config }, request, session),
       request: requestBillingFactory({ api, logger, config }, request, session),
+      cancel: cancelBillingFactory({ api, logger, config }, request, session),
     };
   }
 

--- a/shopify-app-remix/src/billing/__tests__/cancel.test.ts
+++ b/shopify-app-remix/src/billing/__tests__/cancel.test.ts
@@ -1,0 +1,227 @@
+import {
+  BillingInterval,
+  HttpResponseError,
+  SESSION_COOKIE_NAME,
+  Shopify,
+} from "@shopify/shopify-api";
+
+import { shopifyApp } from "../..";
+import {
+  APP_URL,
+  BASE64_HOST,
+  GRAPHQL_URL,
+  TEST_SHOP,
+  expectBeginAuthRedirect,
+  getJwt,
+  getThrownResponse,
+  setUpValidSession,
+  signRequestCookie,
+  testConfig,
+} from "../../__tests__/test-helper";
+import { mockExternalRequest } from "../../__tests__/request-mock";
+import { APP_BRIDGE_REAUTH_HEADER } from "../../auth/helpers/redirect-with-app-bridge-headers";
+
+import * as responses from "./mock-responses";
+
+const BILLING_CONFIG: Shopify["config"]["billing"] = {
+  [responses.PLAN_1]: {
+    amount: 5,
+    currencyCode: "USD",
+    interval: BillingInterval.Every30Days,
+  },
+};
+
+describe("Cancel billing", () => {
+  it("returns an AppSubscription when the cancellation is successful", async () => {
+    // GIVEN
+    const shopify = shopifyApp({ ...testConfig(), billing: BILLING_CONFIG });
+    await setUpValidSession(shopify.sessionStorage);
+
+    const { billing } = await shopify.authenticate.admin(
+      new Request(`${APP_URL}/billing`, {
+        headers: { Authorization: `Bearer ${getJwt().token}` },
+      })
+    );
+
+    await mockExternalRequest({
+      request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
+      response: new Response(responses.CANCEL_RESPONSE),
+    });
+
+    // WHEN
+    const subscription = await billing.cancel({
+      subscriptionId: "123",
+      isTest: true,
+      prorate: true,
+    });
+
+    // THEN
+    expect(subscription).toEqual(responses.APP_SUBSCRIPTION);
+  });
+
+  it("redirects to authentication when at the top level when Shopify invalidated the session", async () => {
+    // GIVEN
+    const config = testConfig();
+    const shopify = shopifyApp({
+      ...config,
+      isEmbeddedApp: false,
+      billing: BILLING_CONFIG,
+    });
+    const session = await setUpValidSession(shopify.sessionStorage);
+
+    const request = new Request(`${APP_URL}/billing?shop=${TEST_SHOP}`);
+    signRequestCookie({
+      request,
+      cookieName: SESSION_COOKIE_NAME,
+      cookieValue: session.id,
+    });
+
+    const { billing } = await shopify.authenticate.admin(request);
+
+    await mockExternalRequest({
+      request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
+      response: new Response(undefined, {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    });
+
+    // WHEN
+    const response = await getThrownResponse(
+      async () =>
+        await billing.cancel({
+          subscriptionId: "123",
+          isTest: true,
+          prorate: true,
+        }),
+      request
+    );
+
+    // THEN
+    expectBeginAuthRedirect(config, response);
+  });
+
+  it("redirects to exit-iframe with authentication using app bridge when embedded and Shopify invalidated the session", async () => {
+    // GIVEN
+    const shopify = shopifyApp({ ...testConfig(), billing: BILLING_CONFIG });
+    await setUpValidSession(shopify.sessionStorage);
+
+    const { token } = getJwt();
+    const request = new Request(
+      `${APP_URL}/billing?embedded=1&shop=${TEST_SHOP}&host=${BASE64_HOST}&id_token=${token}`
+    );
+
+    const { billing } = await shopify.authenticate.admin(request);
+
+    await mockExternalRequest({
+      request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
+      response: new Response(undefined, {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    });
+
+    // WHEN
+    const response = await getThrownResponse(
+      async () =>
+        await billing.cancel({
+          subscriptionId: "123",
+          isTest: true,
+          prorate: true,
+        }),
+      request
+    );
+
+    // THEN
+    expect(response.status).toEqual(302);
+
+    const locationUrl = new URL(
+      response.headers.get("Location")!,
+      "http://test.test"
+    );
+    expect(locationUrl.pathname).toEqual("/auth/exit-iframe");
+    expect(locationUrl.searchParams.get("shop")).toEqual(TEST_SHOP);
+    expect(locationUrl.searchParams.get("host")).toEqual(BASE64_HOST);
+    expect(locationUrl.searchParams.get("exitIframe")).toEqual(
+      `/auth?shop=${TEST_SHOP}`
+    );
+  });
+
+  it("returns redirection headers during fetch requests when Shopify invalidated the session", async () => {
+    // GIVEN
+    const shopify = shopifyApp({ ...testConfig(), billing: BILLING_CONFIG });
+    await setUpValidSession(shopify.sessionStorage);
+
+    const request = new Request(`${APP_URL}/billing`, {
+      headers: {
+        Authorization: `Bearer ${getJwt().token}`,
+      },
+    });
+
+    const { billing } = await shopify.authenticate.admin(request);
+
+    await mockExternalRequest({
+      request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
+      response: new Response(undefined, {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    });
+
+    // WHEN
+    const response = await getThrownResponse(
+      async () =>
+        await billing.cancel({
+          subscriptionId: "123",
+          isTest: true,
+          prorate: true,
+        }),
+      request
+    );
+
+    // THEN
+    expect(response.status).toEqual(401);
+
+    const { origin, pathname } = new URL(
+      response.headers.get(APP_BRIDGE_REAUTH_HEADER)!
+    );
+    expect(origin).toEqual(APP_URL);
+    expect(pathname).toEqual("/auth");
+  });
+
+  it("throws errors other than authentication errors", async () => {
+    // GIVEN
+    const shopify = shopifyApp({
+      ...testConfig(),
+      isEmbeddedApp: false,
+      billing: BILLING_CONFIG,
+    });
+    const session = await setUpValidSession(shopify.sessionStorage);
+
+    await mockExternalRequest({
+      request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
+      response: new Response(undefined, {
+        status: 500,
+        statusText: "Internal Server Error",
+      }),
+    });
+
+    const request = new Request(`${APP_URL}/billing?shop=${TEST_SHOP}`);
+    signRequestCookie({
+      request,
+      cookieName: SESSION_COOKIE_NAME,
+      cookieValue: session.id,
+    });
+
+    const { billing } = await shopify.authenticate.admin(request);
+
+    // THEN
+    await expect(
+      billing.cancel({
+        subscriptionId: "123",
+        isTest: true,
+        prorate: true,
+      })
+    ).rejects.toThrowError(HttpResponseError);
+  });
+});

--- a/shopify-app-remix/src/billing/__tests__/mock-responses.ts
+++ b/shopify-app-remix/src/billing/__tests__/mock-responses.ts
@@ -4,6 +4,12 @@ export const ALL_PLANS = [PLAN_1, PLAN_2];
 
 export const CONFIRMATION_URL = "totally-real-url";
 
+export const APP_SUBSCRIPTION = {
+  id: "gid://123",
+  name: PLAN_1,
+  test: true,
+};
+
 export const EMPTY_SUBSCRIPTIONS = JSON.stringify({
   data: {
     currentAppInstallation: {
@@ -32,11 +38,7 @@ export const EXISTING_SUBSCRIPTION = JSON.stringify({
 export const PURCHASE_SUBSCRIPTION_RESPONSE = JSON.stringify({
   data: {
     appSubscriptionCreate: {
-      appSubscription: {
-        id: "gid://123",
-        name: PLAN_1,
-        test: true,
-      },
+      appSubscription: APP_SUBSCRIPTION,
       confirmationUrl: CONFIRMATION_URL,
       userErrors: [],
     },
@@ -46,13 +48,18 @@ export const PURCHASE_SUBSCRIPTION_RESPONSE = JSON.stringify({
 export const PURCHASE_SUBSCRIPTION_RESPONSE_WITH_USER_ERRORS = JSON.stringify({
   data: {
     appSubscriptionCreate: {
-      appSubscription: {
-        id: "gid://123",
-        name: PLAN_1,
-        test: true,
-      },
+      appSubscription: APP_SUBSCRIPTION,
       confirmationUrl: CONFIRMATION_URL,
       userErrors: ["Oops, something went wrong"],
+    },
+  },
+});
+
+export const CANCEL_RESPONSE = JSON.stringify({
+  data: {
+    appSubscriptionCancel: {
+      appSubscription: APP_SUBSCRIPTION,
+      userErrors: [],
     },
   },
 });

--- a/shopify-app-remix/src/billing/__tests__/request.test.ts
+++ b/shopify-app-remix/src/billing/__tests__/request.test.ts
@@ -46,7 +46,7 @@ describe("Billing request", () => {
     });
     const session = await setUpValidSession(shopify.sessionStorage);
 
-    mockExternalRequests({
+    await mockExternalRequests({
       request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
       response: new Response(responses.PURCHASE_SUBSCRIPTION_RESPONSE),
     });
@@ -78,7 +78,7 @@ describe("Billing request", () => {
     const shopify = shopifyApp({ ...testConfig(), billing: BILLING_CONFIG });
     await setUpValidSession(shopify.sessionStorage);
 
-    mockExternalRequest({
+    await mockExternalRequest({
       request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
       response: new Response(responses.PURCHASE_SUBSCRIPTION_RESPONSE),
     });
@@ -116,7 +116,7 @@ describe("Billing request", () => {
     const shopify = shopifyApp({ ...testConfig(), billing: BILLING_CONFIG });
     await setUpValidSession(shopify.sessionStorage);
 
-    mockExternalRequest({
+    await mockExternalRequest({
       request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
       response: new Response(responses.PURCHASE_SUBSCRIPTION_RESPONSE),
     });
@@ -152,7 +152,7 @@ describe("Billing request", () => {
     });
     const session = await setUpValidSession(shopify.sessionStorage);
 
-    mockExternalRequests({
+    await mockExternalRequests({
       request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
       response: new Response(undefined, {
         status: 401,
@@ -184,7 +184,7 @@ describe("Billing request", () => {
     const shopify = shopifyApp({ ...testConfig(), billing: BILLING_CONFIG });
     await setUpValidSession(shopify.sessionStorage);
 
-    mockExternalRequest({
+    await mockExternalRequest({
       request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
       response: new Response(undefined, {
         status: 401,
@@ -225,7 +225,7 @@ describe("Billing request", () => {
     const shopify = shopifyApp({ ...testConfig(), billing: BILLING_CONFIG });
     await setUpValidSession(shopify.sessionStorage);
 
-    mockExternalRequest({
+    await mockExternalRequest({
       request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
       response: new Response(undefined, {
         status: 401,
@@ -264,7 +264,7 @@ describe("Billing request", () => {
     });
     const session = await setUpValidSession(shopify.sessionStorage);
 
-    mockExternalRequests({
+    await mockExternalRequests({
       request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
       response: new Response(undefined, {
         status: 500,
@@ -292,7 +292,7 @@ describe("Billing request", () => {
     const shopify = shopifyApp({ ...testConfig(), billing: BILLING_CONFIG });
     await setUpValidSession(shopify.sessionStorage);
 
-    mockExternalRequest({
+    await mockExternalRequest({
       request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
       response: new Response(
         responses.PURCHASE_SUBSCRIPTION_RESPONSE_WITH_USER_ERRORS

--- a/shopify-app-remix/src/billing/__tests__/require.test.ts
+++ b/shopify-app-remix/src/billing/__tests__/require.test.ts
@@ -38,7 +38,7 @@ describe("Billing require", () => {
     await setUpValidSession(config.sessionStorage);
     const shopify = shopifyApp({ ...config, billing: BILLING_CONFIG });
 
-    mockExternalRequest({
+    await mockExternalRequest({
       request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
       response: new Response(responses.EMPTY_SUBSCRIPTIONS),
     });
@@ -72,7 +72,7 @@ describe("Billing require", () => {
     await setUpValidSession(config.sessionStorage);
     const shopify = shopifyApp({ ...config, billing: BILLING_CONFIG });
 
-    mockExternalRequest({
+    await mockExternalRequest({
       request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
       response: new Response(responses.EXISTING_SUBSCRIPTION),
     });
@@ -110,7 +110,7 @@ describe("Billing require", () => {
     const session = await setUpValidSession(config.sessionStorage);
     const shopify = shopifyApp(config);
 
-    mockExternalRequest({
+    await mockExternalRequest({
       request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
       response: new Response(undefined, {
         status: 401,
@@ -149,7 +149,7 @@ describe("Billing require", () => {
     await setUpValidSession(config.sessionStorage);
     const shopify = shopifyApp({ ...config, billing: BILLING_CONFIG });
 
-    mockExternalRequest({
+    await mockExternalRequest({
       request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
       response: new Response(undefined, {
         status: 401,
@@ -197,7 +197,7 @@ describe("Billing require", () => {
     await setUpValidSession(config.sessionStorage);
     const shopify = shopifyApp({ ...config, billing: BILLING_CONFIG });
 
-    mockExternalRequest({
+    await mockExternalRequest({
       request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
       response: new Response(undefined, {
         status: 401,
@@ -243,7 +243,7 @@ describe("Billing require", () => {
       billing: BILLING_CONFIG,
     });
 
-    mockExternalRequest({
+    await mockExternalRequest({
       request: new Request(GRAPHQL_URL, { method: "POST", body: "test" }),
       response: new Response(undefined, {
         status: 500,

--- a/shopify-app-remix/src/billing/cancel.ts
+++ b/shopify-app-remix/src/billing/cancel.ts
@@ -1,0 +1,35 @@
+import { HttpResponseError, Session } from "@shopify/shopify-api";
+
+import { BasicParams } from "../types";
+import { CancelBillingOptions } from "./types";
+import { redirectToAuthPage } from "../auth/helpers";
+
+export function cancelBillingFactory(
+  params: BasicParams,
+  request: Request,
+  session: Session
+) {
+  return async function cancelBilling(options: CancelBillingOptions) {
+    const { api, logger } = params;
+
+    logger.debug("Cancelling billing", { shop: session.shop, ...options });
+
+    try {
+      return await api.billing.cancel({
+        session,
+        subscriptionId: options.subscriptionId,
+        isTest: options.isTest,
+        prorate: options.prorate,
+      });
+    } catch (error) {
+      if (error instanceof HttpResponseError && error.response.code === 401) {
+        logger.debug("API token was invalid, redirecting to OAuth", {
+          shop: session.shop,
+        });
+        throw await redirectToAuthPage(params, request, session.shop);
+      } else {
+        throw error;
+      }
+    }
+  };
+}

--- a/shopify-app-remix/src/billing/index.ts
+++ b/shopify-app-remix/src/billing/index.ts
@@ -1,2 +1,3 @@
+export { cancelBillingFactory } from "./cancel";
 export { requireBillingFactory } from "./require";
 export { requestBillingFactory } from "./request";

--- a/shopify-app-remix/src/billing/types.ts
+++ b/shopify-app-remix/src/billing/types.ts
@@ -1,4 +1,5 @@
 import {
+  AppSubscription,
   BillingCheckParams,
   BillingCheckResponseObject,
   BillingRequestParams,
@@ -17,9 +18,16 @@ export interface RequestBillingOptions<Config extends AppConfigArg>
   plan: keyof Config["billing"];
 }
 
+export interface CancelBillingOptions {
+  subscriptionId: string;
+  isTest?: boolean;
+  prorate?: boolean;
+}
+
 export interface BillingContext<Config extends AppConfigArg> {
   require: (
     options: RequireBillingOptions<Config>
   ) => Promise<BillingCheckResponseObject>;
   request: (options: RequestBillingOptions<Config>) => Promise<never>;
+  cancel: (options: CancelBillingOptions) => Promise<AppSubscription>;
 }


### PR DESCRIPTION
This PR exposes the new `cancel` billing method from the library as `billing.cancel`, and it just passes the returning `AppSubscription` object through to the app.