### PR TITLE
Log webhook registration operations

### DIFF
--- a/shopify-app-remix/src/auth/webhooks/register.ts
+++ b/shopify-app-remix/src/auth/webhooks/register.ts
@@ -6,18 +6,18 @@ export function registerWebhooksFactory({ api, logger }: BasicParams) {
   return async function registerWebhooks({ session }: RegisterWebhooksOptions) {
     return api.webhooks.register({ session }).then((response) => {
       Object.entries(response).forEach(([topic, topicResults]) => {
-        topicResults.forEach(({ success, ...result }) => {
+        topicResults.forEach(({ success, ...rest }) => {
           if (success) {
             logger.debug("Registered webhook", {
               topic,
               shop: session.shop,
-              operation: result.operation,
+              operation: rest.operation,
             });
           } else {
             logger.error("Failed to register webhook", {
               topic,
               shop: session.shop,
-              result: result.result,
+              result: rest.result,
             });
           }
         });


### PR DESCRIPTION
Closes #50

Currently, it's very difficult to know what happened by looking at the logs we're outputting from the app package - we'll list topics but we don't really know what happened for each one of them.

Now that the package returns the operation it performed on each of the results (https://github.com/Shopify/shopify-api-js/pull/902), we can include that in the logs.