### PR TITLE
Fix error where Hydration fails

### DIFF
--- a/app/root.jsx
+++ b/app/root.jsx
@@ -31,10 +31,12 @@ export default function App() {
   return (
     <html lang="en">
       <head>
-        <meta name="shopify-api-key" content={apiKey} />
-        <script src="https://cdn.shopify.com/shopifycloud/app-bridge-next/app-bridge.js" />
         <Meta />
         <Links />
+        <script
+          src="https://cdn.shopify.com/shopifycloud/app-bridge-next/app-bridge.js"
+          data-api-key={apiKey}
+        />
       </head>
       <body>
         <PolarisAppProvider i18n={translations}>


### PR DESCRIPTION
Previously we had this error:

<img width="844" alt="Screenshot 2023-06-06 at 11 58 38 AM" src="https://github.com/Shopify/shopify-app-template-remix/assets/690791/7edb14b0-e52a-463c-9f7c-a67cb281107e">

Now we don't.  We still have a Polaris error, but that's a separate issue:  

<img width="1920" alt="Screenshot 2023-06-06 at 12 00 29 PM" src="https://github.com/Shopify/shopify-app-template-remix/assets/690791/4e4de958-aba4-4d52-9feb-80d8ed3d34a0">

