### PR TITLE
Set up Dockerfile for app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.cache
+build
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:18-alpine
+
+ARG SHOPIFY_API_KEY
+ENV SHOPIFY_API_KEY=$SHOPIFY_API_KEY
+
+EXPOSE 3000
+WORKDIR /app
+COPY . .
+
+RUN npm install
+RUN npm run build
+
+# You'll probably want to remove this in production, it's here to make it easier to test things!
+RUN rm prisma/dev.sqlite
+RUN npx prisma migrate dev --name init
+
+CMD ["npm", "run", "start"]

--- a/shopify-app-remix/src/auth/webhooks/register.ts
+++ b/shopify-app-remix/src/auth/webhooks/register.ts
@@ -17,7 +17,7 @@ export function registerWebhooksFactory({ api, logger }: BasicParams) {
             logger.error("Failed to register webhook", {
               topic,
               shop: session.shop,
-              result: rest.result,
+              result: JSON.stringify(rest.result),
             });
           }
         });


### PR DESCRIPTION
Part of #136

When deploying to e.g. fly.io, we use a docker container because that makes it much easier to set up the production environment.

This PR sets up a Dockerfile that successfully runs on fly.io.

I haven't tested Heroku yet because it requires payment information, but I'll probably set it up tomorrow.