### PR TITLE
update ABN script urls to the new shortened URL

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -47,7 +47,7 @@ export default function App() {
         <Meta />
         <Links />
         <script
-          src="https://cdn.shopify.com/shopifycloud/app-bridge-next/app-bridge.js"
+          src="https://cdn.shopify.com/shopifycloud/app-bridge-next.js"
           data-api-key={apiKey}
         />
       </head>

--- a/shopify-app-remix/README.md
+++ b/shopify-app-remix/README.md
@@ -113,7 +113,7 @@ export default function App() {
         <Links />
         {/* App Bridge must be loaded from the CDN at the head */}
         <script
-          src="https://cdn.shopify.com/shopifycloud/app-bridge-next/app-bridge.js"
+          src="https://cdn.shopify.com/shopifycloud/app-bridge-next.js"
           data-api-key={apiKey}
         />
       </head>

--- a/shopify-app-remix/src/auth/admin/__tests__/exit-i-frame-path.test.ts
+++ b/shopify-app-remix/src/auth/admin/__tests__/exit-i-frame-path.test.ts
@@ -29,7 +29,7 @@ describe("authorize.admin exit iframe path", () => {
       "text/html;charset=utf-8"
     );
     expect(responseText).toContain(
-      `<script data-api-key="${config.apiKey}" src="https://cdn.shopify.com/shopifycloud/app-bridge-next/app-bridge.js"></script>`
+      `<script data-api-key="${config.apiKey}" src="https://cdn.shopify.com/shopifycloud/app-bridge-next.js"></script>`
     );
     expect(responseText).toContain(
       `<script>window.open("${decodeURIComponent(exitTo)}", "_top")</script>`
@@ -58,7 +58,7 @@ describe("authorize.admin exit iframe path", () => {
       "text/html;charset=utf-8"
     );
     expect(responseText).toContain(
-      `<script data-api-key="${config.apiKey}" src="https://cdn.shopify.com/shopifycloud/app-bridge-next/app-bridge.js"></script>`
+      `<script data-api-key="${config.apiKey}" src="https://cdn.shopify.com/shopifycloud/app-bridge-next.js"></script>`
     );
     expect(responseText).toContain(
       `<script>window.open("${decodeURIComponent(exitTo)}", "_top")</script>`

--- a/shopify-app-remix/src/auth/admin/__tests__/patch-session-token-path.test.ts
+++ b/shopify-app-remix/src/auth/admin/__tests__/patch-session-token-path.test.ts
@@ -27,7 +27,7 @@ describe("authorize.admin path session token path", () => {
       "text/html;charset=utf-8"
     );
     expect((await response.text()).trim()).toBe(
-      `<script data-api-key="${config.apiKey}" src="https://cdn.shopify.com/shopifycloud/app-bridge-next/app-bridge.js"></script>`
+      `<script data-api-key="${config.apiKey}" src="https://cdn.shopify.com/shopifycloud/app-bridge-next.js"></script>`
     );
   });
 
@@ -51,7 +51,7 @@ describe("authorize.admin path session token path", () => {
       "text/html;charset=utf-8"
     );
     expect((await response.text()).trim()).toContain(
-      `<script data-api-key="${config.apiKey}" src="https://cdn.shopify.com/shopifycloud/app-bridge-next/app-bridge.js"></script>`
+      `<script data-api-key="${config.apiKey}" src="https://cdn.shopify.com/shopifycloud/app-bridge-next.js"></script>`
     );
   });
 });

--- a/shopify-app-remix/src/auth/admin/authenticate.ts
+++ b/shopify-app-remix/src/auth/admin/authenticate.ts
@@ -498,7 +498,7 @@ export class AuthStrategy<
 
     throw new Response(
       `
-        <script data-api-key="${config.apiKey}" src="https://cdn.shopify.com/shopifycloud/app-bridge-next/app-bridge.js"></script>
+        <script data-api-key="${config.apiKey}" src="https://cdn.shopify.com/shopifycloud/app-bridge-next.js"></script>
         ${redirectToScript}
       `,
       { headers: { "content-type": "text/html;charset=utf-8" } }


### PR DESCRIPTION
Related: https://github.com/Shopify/app-bridge-next/pull/68

---

We shortened the ABN script URL from https://cdn.shopify.com/shopifycloud/app-bridge-next/app-bridge.js to https://cdn.shopify.com/shopifycloud/app-bridge-next.js`. Updating this template to use the new script where future deploys will be.