### PR TITLE
Rename shopify.authenticate.storefront to shopify.authenticate.public

### DIFF
--- a/shopify-app-remix/README.md
+++ b/shopify-app-remix/README.md
@@ -283,18 +283,18 @@ export const action = async ({ request }: ActionArgs) => {
 };
 ```
 
-## Authenticating storefront requests
+## Authenticating public requests
 
-Your Remix app may need to authenticate requests coming from a storefront context. Here is how:
+Your Remix app may need to authenticate requests coming from a public context. An example of this would be a checkout extension. Here is how:
 
 ```ts
-// e.g: routes/api/storefront.tsx
+// e.g: routes/api/public/notes.tsx
 import { shopify } from "../shopify.server";
 import { LoaderArgs, json } from "@remix-run/node";
 import { getNotes } from "~/models/notes";
 
 export const loader = async ({ request }: LoaderArgs) => {
-  const { sessionToken } = await shopify.authenticate.storefront(request);
+  const { sessionToken } = await shopify.authenticate.public(request);
 
   // E.g: Get notes using the shops admin domain
   return json(await getNotes(sessionToken.iss));

--- a/shopify-app-remix/src/auth/admin/types.ts
+++ b/shopify-app-remix/src/auth/admin/types.ts
@@ -97,7 +97,7 @@ export interface EmbeddedAdminContext<
    * import { getWidgets } from "~/db/widgets.server";
    *
    * export const loader = async ({ request }: LoaderArgs) => {
-   *   const { sessionToken } = await shopify.authenticate.storefront(
+   *   const { sessionToken } = await shopify.authenticate.public(
    *     request
    *   );
    *   return json(await getWidgets({user: sessionToken.sub}));

--- a/shopify-app-remix/src/auth/public/__tests__/authenticate.test.ts
+++ b/shopify-app-remix/src/auth/public/__tests__/authenticate.test.ts
@@ -14,7 +14,7 @@ describe("JWT validation", () => {
     const { token, payload } = getJwt();
 
     // WHEN
-    const { sessionToken } = await shopify.authenticate.storefront(
+    const { sessionToken } = await shopify.authenticate.public(
       new Request(APP_URL, {
         headers: {
           Authorization: `Bearer ${token}`,
@@ -33,7 +33,7 @@ describe("JWT validation", () => {
 
     // WHEN
     const response = await getThrownResponse(
-      shopify.authenticate.storefront,
+      shopify.authenticate.public,
       new Request(APP_URL)
     );
 
@@ -48,7 +48,7 @@ describe("JWT validation", () => {
 
     // WHEN
     const response = await getThrownResponse(
-      shopify.authenticate.storefront,
+      shopify.authenticate.public,
       new Request(APP_URL, {
         headers: { Authorization: `Bearer this_is_not_a_valid_token` },
       })
@@ -65,7 +65,7 @@ describe("JWT validation", () => {
 
     // WHEN
     const response = await getThrownResponse(
-      shopify.authenticate.storefront,
+      shopify.authenticate.public,
       new Request(APP_URL, {
         headers: { "User-Agent": "Googlebot" },
       })

--- a/shopify-app-remix/src/auth/public/authenticate.ts
+++ b/shopify-app-remix/src/auth/public/authenticate.ts
@@ -1,23 +1,23 @@
 import { BasicParams } from "../../types";
 
-import { StorefrontContext } from "./types";
+import { PublicContext } from "./types";
 import {
   getSessionTokenHeader,
   rejectBotRequest,
   validateSessionToken,
 } from "../helpers";
 
-export function authenticateStorefrontFactory(params: BasicParams) {
-  return async function authenticateStorefront(
+export function authenticatePublicFactory(params: BasicParams) {
+  return async function authenticatePublic(
     request: Request
-  ): Promise<StorefrontContext> {
+  ): Promise<PublicContext> {
     const { logger } = params;
 
     rejectBotRequest(params, request);
 
     const sessionTokenHeader = getSessionTokenHeader(request);
 
-    logger.info("Authenticating storefront request");
+    logger.info("Authenticating public request");
 
     if (!sessionTokenHeader) {
       logger.debug("Request did not contain a session token");

--- a/shopify-app-remix/src/auth/public/types.ts
+++ b/shopify-app-remix/src/auth/public/types.ts
@@ -1,26 +1,26 @@
 import { JwtPayload } from "@shopify/shopify-api";
 
 /**
- * Authenticated Context for a storefront request
+ * Authenticated Context for a public request
  */
-export interface StorefrontContext {
+export interface PublicContext {
   /**
    * The decoded and validated session token for the request
    *
-   * {@link https://shopify.dev/docs/apps/auth/oauth/session-tokens#payload}
+   * The payload of the Session Token is described here: {@link https://shopify.dev/docs/apps/auth/oauth/session-tokens#payload}
    *
    * @example
-   * Getting your app's user specific widget data using the session token
-   * // app/routes/**\/.ts
+   * Getting your app's store specific widget data using the session token
+   * // app/routes/public/widgets.ts
    * import { LoaderArgs, json } from "@remix-run/node";
    * import { shopify } from "../shopify.server";
    * import { getWidgets } from "~/db/widgets.server";
    *
    * export const loader = async ({ request }: LoaderArgs) => {
-   *   const { sessionToken } = await shopify.authenticate.storefront(
+   *   const { sessionToken } = await shopify.authenticate.public(
    *     request
    *   );
-   *   return json(await getWidgets({user: sessionToken.sub}));
+   *   return json(await getWidgets({shop: sessionToken.dest}));
    * };
    */
   sessionToken: JwtPayload;

--- a/shopify-app-remix/src/index.ts
+++ b/shopify-app-remix/src/index.ts
@@ -17,7 +17,7 @@ import { BasicParams, MandatoryTopics, ShopifyApp } from "./types";
 import { registerWebhooksFactory } from "./auth/webhooks";
 import { AuthStrategy } from "./auth/admin/authenticate";
 import { authenticateWebhookFactory } from "./auth/webhooks/authenticate";
-import { authenticateStorefrontFactory } from "./auth/storefront/authenticate";
+import { authenticatePublicFactory } from "./auth/public/authenticate";
 import { overrideLogger } from "./override-logger";
 
 export { ShopifyApp } from "./types";
@@ -69,7 +69,7 @@ export function shopifyApp<
     registerWebhooks: registerWebhooksFactory(params),
     authenticate: {
       admin: oauth.authenticateAdmin.bind(oauth),
-      storefront: authenticateStorefrontFactory(params),
+      public: authenticatePublicFactory(params),
       webhook: authenticateWebhookFactory<
         Resources,
         keyof Config["webhooks"] | MandatoryTopics

--- a/shopify-app-remix/src/types.ts
+++ b/shopify-app-remix/src/types.ts
@@ -7,7 +7,7 @@ import { SessionStorage } from "@shopify/shopify-app-session-storage";
 
 import { AppConfig, AppConfigArg } from "./config-types";
 import { AdminContext } from "./auth/admin/types";
-import { StorefrontContext } from "./auth/storefront/types";
+import { PublicContext } from "./auth/public/types";
 import { RegisterWebhooksOptions } from "./auth/webhooks/types";
 import { WebhookContext } from "./auth/webhooks/types";
 
@@ -40,7 +40,7 @@ type AuthenticateAdmin<
   Resources extends ShopifyRestResources = ShopifyRestResources
 > = (request: Request) => Promise<AdminContext<Config, Resources>>;
 
-type AuthenticateStorefront = (request: Request) => Promise<StorefrontContext>;
+type AuthenticatePublic = (request: Request) => Promise<PublicContext>;
 
 type AuthenticateWebhook<
   Resources extends ShopifyRestResources = ShopifyRestResources,
@@ -164,12 +164,12 @@ export interface ShopifyApp<Config extends AppConfigArg> {
     admin: AuthenticateAdmin<Config, RestResourcesType<Config>>;
 
     /**
-     * Authenticate a storefront request and get back a session token
+     * Authenticate a public request and get back a session token
      *
      * An example of when to use this is a request from a checkout extension.
      *
      * @param request `Request` The incoming request to authenticate
-     * @returns `Promise<StorefrontContext>` An authenticated storefront context
+     * @returns `Promise<PublicContext>` An authenticated public context
      *
      * @example
      * Authenticating a request from a checkout extension
@@ -181,19 +181,19 @@ export interface ShopifyApp<Config extends AppConfigArg> {
      * import { getWidgets } from "~/db/widgets";
      *
      * export async function loader({ request }: LoaderArgs) {
-     *   const {sessionToken} = shopify.authenticate.storefront(request);
+     *   const {sessionToken} = shopify.authenticate.public(request);
      *
      *   return json(await getWidgets(sessionToken));
      * }
      * ```
      */
-    storefront: AuthenticateStorefront;
+    public: AuthenticatePublic;
 
     /**
      * Authenticate a Shopify webhook request, get back an authenticated admin context and details on the webhook request
      *
      * @param request `Request` The incoming request to authenticate
-     * @returns `Promise<StorefrontContext>` An authenticated storefront context
+     * @returns `Promise<PublicContext>` An authenticated public context
      *
      * @example
      * Authenticating a webhook request


### PR DESCRIPTION
We want to make it _really_ explicit that this is for public surfaces, so be careful about what you expose.  Here we rename `shopify.authenticate.storefront` to `shopify.authenticate.public`

@ragalie or @RyanDJLee Please could you double check that you are ok with the TSDOC comments?