### PR TITLE
Use CLI env var for custom shop domains

### DIFF
--- a/app/shopify.server.ts
+++ b/app/shopify.server.ts
@@ -39,4 +39,7 @@ export const shopify = shopifyApp({
       interval: BillingInterval.Every30Days,
     },
   },
+  ...(process.env.SHOP_CUSTOM_DOMAIN
+    ? { customShopDomains: [process.env.SHOP_CUSTOM_DOMAIN] }
+    : {}),
 });


### PR DESCRIPTION
Closes #155

The CLI sets a `SHOP_CUSTOM_DOMAIN` for spin apps. To make it easier to... spin them up, we can support that out of the box in the template.