### PR TITLE
Use exit-iframe when beginning auth in frame

### DIFF
--- a/shopify-app-remix/src/__tests__/test-helper.ts
+++ b/shopify-app-remix/src/__tests__/test-helper.ts
@@ -173,3 +173,33 @@ export function expectBeginAuthRedirect(
   );
   expect(searchParams.get("state")).toStrictEqual(expect.any(String));
 }
+
+interface ExpectExitIframeRedirectOptions {
+  shop?: string;
+  host?: string | null;
+  destination?: string;
+}
+
+export function expectExitIframeRedirect(
+  response: Response,
+  {
+    shop = TEST_SHOP,
+    host = BASE64_HOST,
+    destination = `/auth?shop=${shop}`
+  }: ExpectExitIframeRedirectOptions = {}
+) {
+  expect(response.status).toBe(302);
+
+  const { pathname, searchParams } = new URL(
+    response.headers.get("location")!,
+    APP_URL
+  );
+  expect(pathname).toBe("/auth/exit-iframe");
+
+  expect(searchParams.get("shop")).toBe(shop);
+  expect(searchParams.get("exitIframe")).toBe(destination);
+
+  if (host) {
+    expect(searchParams.get("host")).toBe(host);
+  }
+}

--- a/shopify-app-remix/src/auth/admin/__tests__/auth-path.test.ts
+++ b/shopify-app-remix/src/auth/admin/__tests__/auth-path.test.ts
@@ -3,6 +3,7 @@ import {
   APP_URL,
   TEST_SHOP,
   expectBeginAuthRedirect,
+  expectExitIframeRedirect,
   getThrownResponse,
   testConfig,
 } from "../../../__tests__/test-helper";
@@ -54,5 +55,37 @@ describe("authorize.admin auth path", () => {
 
     // THEN
     expectBeginAuthRedirect(config, response);
+  });
+
+  test('redirects to exit-iframe when loading the auth path while in a fetch request', async () => {
+    // GIVEN
+    const config = testConfig();
+    const shopify = shopifyApp(config);
+
+    // WHEN
+    const url = `${APP_URL}/auth?shop=${TEST_SHOP}`;
+    const response = await getThrownResponse(
+      shopify.authenticate.admin,
+      new Request(url, { headers: { 'Sec-Fetch-Dest': 'empty' } })
+    );
+
+    // THEN
+    expectExitIframeRedirect(response, { host: null });
+  });
+
+  test('redirects to exit-iframe when loading the auth path while in an iframe request', async () => {
+    // GIVEN
+    const config = testConfig();
+    const shopify = shopifyApp(config);
+
+    // WHEN
+    const url = `${APP_URL}/auth?shop=${TEST_SHOP}`;
+    const response = await getThrownResponse(
+      shopify.authenticate.admin,
+      new Request(url, { headers: { 'Sec-Fetch-Dest': 'iframe' } })
+    );
+
+    // THEN
+    expectExitIframeRedirect(response, { host: null });
   });
 });

--- a/shopify-app-remix/src/auth/admin/__tests__/client-overrides.test.ts
+++ b/shopify-app-remix/src/auth/admin/__tests__/client-overrides.test.ts
@@ -11,6 +11,7 @@ import {
   APP_URL,
   BASE64_HOST,
   TEST_SHOP,
+  expectExitIframeRedirect,
   getJwt,
   getThrownResponse,
   setUpValidSession,
@@ -126,19 +127,7 @@ describe("admin.authenticate context", () => {
         );
 
         // THEN
-        expect(response.status).toEqual(302);
-
-        const { pathname, searchParams } = new URL(
-          response.headers.get("Location")!,
-          APP_URL
-        );
-
-        expect(pathname).toEqual("/auth/exit-iframe");
-        expect(searchParams.get("shop")).toEqual(TEST_SHOP);
-        expect(searchParams.get("host")).toEqual(BASE64_HOST);
-        expect(searchParams.get("exitIframe")).toEqual(
-          `/auth?shop=${TEST_SHOP}`
-        );
+        expectExitIframeRedirect(response);
       });
 
       it("returns app bridge redirection headers when request receives a 401 response on fetch requests", async () => {

--- a/shopify-app-remix/src/auth/admin/__tests__/doc-request-path.test.ts
+++ b/shopify-app-remix/src/auth/admin/__tests__/doc-request-path.test.ts
@@ -13,6 +13,7 @@ import {
   SHOPIFY_HOST,
   TEST_SHOP,
   expectBeginAuthRedirect,
+  expectExitIframeRedirect,
   getJwt,
   getThrownResponse,
   setUpValidSession,
@@ -73,16 +74,7 @@ describe("authorize.admin doc request path", () => {
       );
 
       // THEN
-      expect(response.status).toBe(302);
-
-      const { pathname, searchParams } = new URL(
-        response.headers.get("location")!,
-        APP_URL
-      );
-      expect(pathname).toBe("/auth/exit-iframe");
-      expect(searchParams.get("shop")).toBe(TEST_SHOP);
-      expect(searchParams.get("host")).toBe(BASE64_HOST);
-      expect(searchParams.get("exitIframe")).toBe(`/auth?shop=${TEST_SHOP}`);
+      expectExitIframeRedirect(response);
     });
 
     it("redirects to auth when not embedded on an embedded app, and the API token is invalid", async () => {
@@ -246,18 +238,7 @@ describe("authorize.admin doc request path", () => {
       );
 
       // THEN
-      expect(response.status).toBe(302);
-
-      const { pathname, searchParams } = new URL(
-        response.headers.get("location")!,
-        APP_URL
-      );
-      expect(pathname).toBe("/auth/exit-iframe");
-      expect(searchParams.get("shop")).toBe(otherShopDomain);
-      expect(searchParams.get("host")).toBe(BASE64_HOST);
-      expect(searchParams.get("exitIframe")).toBe(
-        `/auth?shop=${otherShopDomain}`
-      );
+      expectExitIframeRedirect(response, { shop: otherShopDomain });
     });
 
     it("redirects to exit-iframe if app is embedded and the session is no longer valid for the id_token when embedded", async () => {
@@ -275,16 +256,7 @@ describe("authorize.admin doc request path", () => {
       );
 
       // THEN
-      const { pathname, searchParams } = new URL(
-        response.headers.get("location")!,
-        APP_URL
-      );
-
-      expect(response.status).toBe(302);
-      expect(pathname).toBe("/auth/exit-iframe");
-      expect(searchParams.get("shop")).toBe(TEST_SHOP);
-      expect(searchParams.get("host")).toBe(BASE64_HOST);
-      expect(searchParams.get("exitIframe")).toBe(`/auth?shop=${TEST_SHOP}`);
+      expectExitIframeRedirect(response);
     });
 
     it("redirects to auth if there is no session cookie for non-embedded apps when at the top level", async () => {

--- a/shopify-app-remix/src/auth/helpers/redirect-with-exitiframe.ts
+++ b/shopify-app-remix/src/auth/helpers/redirect-with-exitiframe.ts
@@ -10,9 +10,14 @@ export function redirectWithExitIframe(
   const url = new URL(request.url);
 
   const queryParams = url.searchParams;
+  const host = api.utils.sanitizeHost(queryParams.get("host")!);
+
   queryParams.set("shop", shop);
-  queryParams.set("host", api.utils.sanitizeHost(queryParams.get("host")!)!);
   queryParams.set("exitIframe", `${config.auth.path}?shop=${shop}`);
+
+  if (host) {
+    queryParams.set("host", host);
+  }
 
   throw redirect(`${config.auth.exitIframePath}?${queryParams.toString()}`);
 }

--- a/shopify-app-remix/src/billing/__tests__/cancel.test.ts
+++ b/shopify-app-remix/src/billing/__tests__/cancel.test.ts
@@ -12,6 +12,7 @@ import {
   GRAPHQL_URL,
   TEST_SHOP,
   expectBeginAuthRedirect,
+  expectExitIframeRedirect,
   getJwt,
   getThrownResponse,
   setUpValidSession,
@@ -133,18 +134,7 @@ describe("Cancel billing", () => {
     );
 
     // THEN
-    expect(response.status).toEqual(302);
-
-    const locationUrl = new URL(
-      response.headers.get("Location")!,
-      "http://test.test"
-    );
-    expect(locationUrl.pathname).toEqual("/auth/exit-iframe");
-    expect(locationUrl.searchParams.get("shop")).toEqual(TEST_SHOP);
-    expect(locationUrl.searchParams.get("host")).toEqual(BASE64_HOST);
-    expect(locationUrl.searchParams.get("exitIframe")).toEqual(
-      `/auth?shop=${TEST_SHOP}`
-    );
+    expectExitIframeRedirect(response);
   });
 
   it("returns redirection headers during fetch requests when Shopify invalidated the session", async () => {

--- a/shopify-app-remix/src/billing/__tests__/request.test.ts
+++ b/shopify-app-remix/src/billing/__tests__/request.test.ts
@@ -13,6 +13,7 @@ import {
   GRAPHQL_URL,
   TEST_SHOP,
   expectBeginAuthRedirect,
+  expectExitIframeRedirect,
   getJwt,
   getThrownResponse,
   setUpValidSession,
@@ -97,18 +98,7 @@ describe("Billing request", () => {
     );
 
     // THEN
-    expect(response.status).toEqual(302);
-
-    const locationUrl = new URL(
-      response.headers.get("Location")!,
-      "http://test.test"
-    );
-    expect(locationUrl.pathname).toEqual("/auth/exit-iframe");
-    expect(locationUrl.searchParams.get("shop")).toEqual(TEST_SHOP);
-    expect(locationUrl.searchParams.get("host")).toEqual(BASE64_HOST);
-    expect(locationUrl.searchParams.get("exitIframe")).toEqual(
-      responses.CONFIRMATION_URL
-    );
+    expectExitIframeRedirect(response, { destination: responses.CONFIRMATION_URL });
   });
 
   it("returns redirection headers when successful during fetch requests", async () => {
@@ -208,18 +198,7 @@ describe("Billing request", () => {
     );
 
     // THEN
-    expect(response.status).toEqual(302);
-
-    const locationUrl = new URL(
-      response.headers.get("Location")!,
-      "http://test.test"
-    );
-    expect(locationUrl.pathname).toEqual("/auth/exit-iframe");
-    expect(locationUrl.searchParams.get("shop")).toEqual(TEST_SHOP);
-    expect(locationUrl.searchParams.get("host")).toEqual(BASE64_HOST);
-    expect(locationUrl.searchParams.get("exitIframe")).toEqual(
-      `/auth?shop=${TEST_SHOP}`
-    );
+    expectExitIframeRedirect(response);
   });
 
   it("returns redirection headers during fetch requests when Shopify invalidated the session", async () => {

--- a/shopify-app-remix/src/billing/__tests__/require.test.ts
+++ b/shopify-app-remix/src/billing/__tests__/require.test.ts
@@ -12,6 +12,7 @@ import {
   GRAPHQL_URL,
   TEST_SHOP,
   expectBeginAuthRedirect,
+  expectExitIframeRedirect,
   getJwt,
   getThrownResponse,
   setUpValidSession,
@@ -177,18 +178,7 @@ describe("Billing require", () => {
     );
 
     // THEN
-    expect(response.status).toEqual(302);
-
-    const locationUrl = new URL(
-      response.headers.get("Location")!,
-      "http://test.test"
-    );
-    expect(locationUrl.pathname).toEqual("/auth/exit-iframe");
-    expect(locationUrl.searchParams.get("shop")).toEqual(TEST_SHOP);
-    expect(locationUrl.searchParams.get("host")).toEqual(BASE64_HOST);
-    expect(locationUrl.searchParams.get("exitIframe")).toEqual(
-      `/auth?shop=${TEST_SHOP}`
-    );
+    expectExitIframeRedirect(response);
   });
 
   it("returns redirection headers during fetch requests when Shopify invalidated the session", async () => {


### PR DESCRIPTION
If an app redirects the user to `/auth` while inside the iframe, we would go into a loop because oauth doesn't work inside the iframe.

We need to detect that case and break out so that the app continues to work.

Questions:
- Can we rely on that header for the source?
- Is there any safety concern here I'm missing?