### PR TITLE
Block non-POST webhook requests

### DIFF
--- a/shopify-app-remix/src/auth/webhooks/__tests__/authenticate.test.ts
+++ b/shopify-app-remix/src/auth/webhooks/__tests__/authenticate.test.ts
@@ -24,8 +24,7 @@ describe("Webhook validation", () => {
   it("returns context when successful", async () => {
     // GIVEN
     const sessionStorage = new MemorySessionStorage();
-    const config = testConfig({ sessionStorage, restResources });
-    const shopify = shopifyApp(config);
+    const shopify = shopifyApp(testConfig({ sessionStorage, restResources }));
     const body = {some: "data"};
 
     const session = new Session({
@@ -71,8 +70,7 @@ describe("Webhook validation", () => {
 
   it("throws a 400 on invalid HMAC", async () => {
     // GIVEN
-    const config = testConfig();
-    const shopify = shopifyApp(config);
+    const shopify = shopifyApp(testConfig());
 
     // WHEN
     const response = await getThrownResponse(
@@ -98,8 +96,7 @@ describe("Webhook validation", () => {
     "X-Shopify-Hmac-Sha256",
   ])("throws a 400 when header %s is missing", async (header) => {
     // GIVEN
-    const config = testConfig();
-    const shopify = shopifyApp(config);
+    const shopify = shopifyApp(testConfig());
 
     // WHEN
     const response = await getThrownResponse(
@@ -118,8 +115,7 @@ describe("Webhook validation", () => {
   it("throws a 404 on missing sessions", async () => {
     // GIVEN
     const sessionStorage = new MemorySessionStorage();
-    const config = testConfig({ sessionStorage });
-    const shopify = shopifyApp(config);
+    const shopify = shopifyApp(testConfig({ sessionStorage }));
 
     // WHEN
     const response = await getThrownResponse(
@@ -133,6 +129,23 @@ describe("Webhook validation", () => {
 
     // THEN
     expect(response.status).toBe(404);
+  });
+
+  it("throws a 405 Method Not Allowed on non-POST requests", async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+
+    // WHEN
+    const response = await getThrownResponse(
+      shopify.authenticate.webhook,
+      new Request(`${APP_URL}/webhooks`, {
+        method: "GET",
+        headers: webhookHeaders(JSON.stringify({})),
+      })
+    );
+
+    // THEN
+    expect(response.status).toBe(405);
   });
 });
 

--- a/shopify-app-remix/src/auth/webhooks/authenticate.ts
+++ b/shopify-app-remix/src/auth/webhooks/authenticate.ts
@@ -11,10 +11,16 @@ export function authenticateWebhookFactory<
   return async function authenticate(
     request: Request
   ): Promise<WebhookContext<Topics, Resources>> {
+    if (request.method !== "POST") {
+      logger.debug(
+        "Received a non-POST request for a webhook. Only POST requests are allowed.",
+        { url: request.url, method: request.method }
+      );
+      throw new Response(undefined, { status: 405, statusText: "Method not allowed" });
+    }
+
     const rawBody = await request.text();
 
-    // TODO: Webhooks can only be POST requests, we should fail early in any other scenario
-    // https://github.com/orgs/Shopify/projects/6899/views/1?pane=issue&itemId=28378576
     const check = await api.webhooks.validate({
       rawBody,
       rawRequest: request,


### PR DESCRIPTION
Closes #49

As per the issue, any non-POST request for webhooks is suspicious and invalid, we don't want to handle those.