### PR TITLE
Fix app bridge text key name

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -9,7 +9,7 @@
     "yourAppIsReadyToExplore": "Your app is ready to explore! It contains everything you need to get started including the {{polarisLink}}, {{adminApiLink}}, and {{appBridgeLink}} UI library and components.",
     "polarisLinkText": "Polaris design system",
     "adminApiLinkText": "Shopify Admin API",
-    "AppBridgeLink": "App Bridge"
+    "appBridgeLinkText": "App Bridge"
   },
   "ProductsCard": {
     "description": "Sample products are created with a default title and price. You can remove them at any time.",


### PR DESCRIPTION
Fixing an incorrect locale key name introduced in https://github.com/Shopify/shopify-app-template-remix/pull/170.