### PR TITLE
Set thrown response headers in app layout boundary

### DIFF
--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { json } from "@remix-run/node";
-import type { ActionArgs, LoaderArgs, HeadersFunction } from "@remix-run/node";
+import type { ActionArgs, LoaderArgs } from "@remix-run/node";
 import {
   Form,
   useActionData,
@@ -265,17 +265,3 @@ export default function Index() {
     </Page>
   );
 }
-
-// TODO: We need to explicitly catch errors with a boundary here because some embedded app features rely on non-200
-// thrown responses (such as re-authentication requests or billing).
-// See https://github.com/remix-run/remix/pull/6425
-export function CatchBoundary() {
-  return <h1>Error occurred.</h1>;
-}
-
-export const headers: HeadersFunction = ({ loaderHeaders, actionHeaders }) => {
-  return new Headers([
-    ...(actionHeaders ? Array.from(actionHeaders.entries()) : []),
-    ...(loaderHeaders ? Array.from(loaderHeaders.entries()) : []),
-  ]);
-};

--- a/app/routes/app.localization.tsx
+++ b/app/routes/app.localization.tsx
@@ -10,7 +10,7 @@ import {
   VerticalStack,
 } from "@shopify/polaris";
 import { useTranslation } from "react-i18next";
-import type { HeadersFunction, LoaderArgs } from "@remix-run/node";
+import type { LoaderArgs } from "@remix-run/node";
 
 import { shopify } from "../shopify.server";
 
@@ -95,11 +95,3 @@ export default function Localization() {
     </Page>
   );
 }
-
-export function CatchBoundary() {
-  return <h1>Error occurred.</h1>;
-}
-
-export const headers: HeadersFunction = ({ loaderHeaders }) => {
-  return loaderHeaders;
-};

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import { type LinksFunction, json } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import type { HeadersFunction, LinksFunction } from "@remix-run/node";
 import { Link, Outlet, useLoaderData } from "@remix-run/react";
 import { AppProvider as PolarisAppProvider } from "@shopify/polaris";
 import { Provider as AppBridgeReactProvider } from "@shopify/app-bridge-react";
@@ -11,8 +12,25 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: polarisStyles },
 ];
 
-export const handle = {
-  useAppBridge: true,
+// We need to catch errors at this point so we can ensure the headers are included in the response. This should never be
+// rendered.
+export function CatchBoundary() {
+  return <h1>Error occurred.</h1>;
+}
+
+export const headers: HeadersFunction = ({
+  loaderHeaders,
+  actionHeaders,
+  errorHeaders,
+  parentHeaders,
+}) => {
+  // Ensure all of the headers Shopify needs are set for embedded app requests
+  return new Headers([
+    ...(actionHeaders ? Array.from(actionHeaders.entries()) : []),
+    ...(loaderHeaders ? Array.from(loaderHeaders.entries()) : []),
+    ...(errorHeaders ? Array.from(errorHeaders.entries()) : []),
+    ...(parentHeaders ? Array.from(parentHeaders.entries()) : []),
+  ]);
 };
 
 export async function loader({ request }) {

--- a/remix.config.js
+++ b/remix.config.js
@@ -18,5 +18,6 @@ module.exports = {
   appDirectory: "app",
   future: {
     v2_routeConvention: true,
+    v2_headers: true,
   },
 };


### PR DESCRIPTION
This PR is just moving the header-setting error boundaries we needed to set at every level to the app layout level, so that developers don't need to worry about setting them up on every page they create.