### PR TITLE
Link to unified admin so we avoid a redirect

### DIFF
--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -26,7 +26,7 @@ import { shopify } from "../shopify.server";
 export const loader = async ({ request }) => {
   const { session } = await shopify.authenticate.admin(request);
 
-  return json({ shop: session.shop });
+  return json({ shop: session.shop.replace(".myshopify.com", "") });
 };
 
 export async function action({ request }) {
@@ -135,7 +135,7 @@ export default function Index() {
                   {actionData?.product && (
                     <Button
                       plain
-                      url={`https://${shop}/admin/products/${productId}`}
+                      url={`https://admin.shopify.com/store/${shop}/admin/products/${productId}`}
                       target="_blank"
                     >
                       View product


### PR DESCRIPTION
When you click the view product link you see a redirect.  By link to the unified admin URL there is no redirect.