### PR TITLE
Check TS types in JS files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
     "target": "ES2019",
     "strict": true,
     "allowJs": true,
+    "checkJs": true,
+    "noImplicitAny": false,
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
Currently, our JS files are completely untyped, which also makes it harder to catch simple mistakes due to most of the type inference not working completely.

This PR attempts to remedy that by changing the `jsconfig` file to `tsconfig`, checking JS files (but still allowing untyped or "implicit any" variables).

E.g. this will fail while we don't add the types for app bridge to the project:

![image](https://github.com/Shopify/shopify-app-template-remix/assets/64600052/6074e6bd-1530-405c-b691-a3667a10a4c0)

Or for instance if you call a function incorrectly:

![image](https://github.com/Shopify/shopify-app-template-remix/assets/64600052/4771bd45-8bce-4a11-b9bb-5478e4dea430)

But developers will also be able to get proper types when writing code in JS files:

![image](https://github.com/Shopify/shopify-app-template-remix/assets/64600052/fbe08cb8-cb2d-4329-8864-f71e47c29b9e)
