### PR TITLE
Use default Remix error boundary behaviour in app layout

### DIFF
--- a/app/routes/app.jsx
+++ b/app/routes/app.jsx
@@ -33,8 +33,8 @@ export default function App() {
   );
 }
 
-// We need to catch errors at this point so we can ensure the headers are included in the response. We still want the
-// default Remix error boundary behavior, so we rethrow the error after we've captured the headers.
+// Shopify methods such as billing.require() need Remix to catch errors so headers are included in the response.
+// We throw `useRouteError()` to retain Remix's default error behaviour after we've captured headers.
 export function ErrorBoundary() {
   throw useRouteError();
 }


### PR DESCRIPTION
Closes #240 

Currently, we're catching errors in the error boundary and throwing all of the data they bring in a void. This is fine for our own internal "error"-based navigation (e.g. redirecting with AB headers), but when actual errors happen and they're not caught, we don't provide any helpful information.

Turns out that we can have the best of both worlds by re-throwing the error from the error boundary. That will trigger the default Remix error behaviour which renders a stack trace and some extra info, while still causing the headers to be applied.

Followed [the docs here](https://remix.run/docs/en/main/pages/v2#catchboundary-and-errorboundary) so this should be 100% v2 compatible!