### PR TITLE
Use latest API version

### DIFF
--- a/app/shopify.server.js
+++ b/app/shopify.server.js
@@ -5,7 +5,7 @@ import {
   shopifyApp,
 } from "@shopify/shopify-app-remix";
 import { PrismaSessionStorage } from "@shopify/shopify-app-session-storage-prisma";
-import { restResources } from "@shopify/shopify-api/rest/admin/2023-04";
+import { restResources } from "@shopify/shopify-api/rest/admin/2023-07";
 
 import prisma from "./db.server";
 


### PR DESCRIPTION
This PR simply updates the API version we pull the REST resources from.

This makes me think - do we want to pull in the resources by default if we're not using them?