### PR TITLE
Add shorthands for link, push and use commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "scripts": {
     "build": "NODE_ENV=production remix build",
     "dev": "shopify app dev",
-    "push": "shopify app push",
+    "link": "shopify app config link",
+    "push": "shopify app config push",
     "generate": "shopify app generate",
     "deploy": "shopify app deploy",
+    "use": "shopify app config use",
     "env": "shopify app env",
     "start": "remix-serve build",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",


### PR DESCRIPTION
Resolves: https://github.com/Shopify/internal-cli-foundations/issues/731
This PR ensure that we have the appropriate shorthands for the new CLI commands.

#### 🎩 
1. Clone the repo and run `npm install` & `npm run setup`
2. Run `npm install @shopify/cli@nightly` & `npm install @shopify/app@nightly` versions
3. Run the following commands to ensure they are working

```bash
npm run link
```

```bash
npm run use
```

```bash
npm run push
```