### PR TITLE
Replace faker with simple randomizer

### DIFF
--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -19,7 +19,6 @@ import {
   Link,
   List,
 } from "@shopify/polaris";
-import { faker } from "@faker-js/faker";
 
 import { shopify } from "../shopify.server";
 
@@ -32,6 +31,9 @@ export const loader = async ({ request }) => {
 export async function action({ request }) {
   const { admin } = await shopify.authenticate.admin(request);
 
+  const color = ["Red", "Orange", "Yellow", "Green"][
+    Math.floor(Math.random() * 4)
+  ];
   const response = await admin.graphql(
     `#graphql
       mutation populateProduct($input: ProductInput!) {
@@ -57,7 +59,7 @@ export async function action({ request }) {
     {
       variables: {
         input: {
-          title: faker.commerce.productName(),
+          title: `${color} Snowboard`,
           variants: [{ price: Math.random() * 100 }],
         },
       },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "setup": "prisma generate && prisma migrate deploy"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.0.2",
     "@prisma/client": "^4.13.0",
     "@remix-run/node": "^1.19.0-pre.0",
     "@remix-run/react": "^1.19.0-pre.0",


### PR DESCRIPTION
Faker is a fairly large package, amounting to nearly 30MB of disk space for the sole purpose of producing random product names.

Instead of pulling in a lot of code that will essentially be removed and force partners to remove the dependency, we will just use an extremely simple randomizer to add a colour to a "Snowboard" name so it's not always the same.