### PR TITLE
Use config:link as the shorthand to avoid collisions with yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "NODE_ENV=production remix build",
     "dev": "shopify app dev",
-    "link": "shopify app config link",
+    "config:link": "shopify app config link",
     "push": "shopify app config push",
     "generate": "shopify app generate",
     "deploy": "shopify app deploy",


### PR DESCRIPTION
This PR renames the shorthand to `config:link` in order to avoid collision with [yarn link](https://classic.yarnpkg.com/en/docs/cli/link).