### PR TITLE
Rearrange shopify object exports

### DIFF
--- a/app/entry.server.jsx
+++ b/app/entry.server.jsx
@@ -4,7 +4,7 @@ import { Response } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 
-import { shopify } from "./shopify.server";
+import { addResponseHeaders } from "./shopify.server";
 
 const ABORT_DELAY = 5_000;
 
@@ -15,7 +15,7 @@ export default async function handleRequest(
   remixContext,
   _loadContext
 ) {
-  shopify.addResponseHeaders(request, responseHeaders);
+  addResponseHeaders(request, responseHeaders);
 
   const callbackName = isbot(request.headers.get("user-agent"))
     ? "onAllReady"

--- a/app/routes/_index/route.jsx
+++ b/app/routes/_index/route.jsx
@@ -1,7 +1,7 @@
 import { json, redirect } from "@remix-run/node";
 import { Form, useLoaderData } from "@remix-run/react";
 
-import { shopify } from "../../shopify.server";
+import { canUseLoginForm } from "../../shopify.server";
 
 import indexStyles from "./style.css";
 
@@ -14,7 +14,7 @@ export async function loader({ request }) {
     throw redirect(`/app?${url.searchParams.toString()}`);
   }
 
-  return json({ showForm: shopify.canUseLoginForm });
+  return json({ showForm: canUseLoginForm });
 }
 
 export default function App() {

--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -20,16 +20,16 @@ import {
   List,
 } from "@shopify/polaris";
 
-import { shopify } from "../shopify.server";
+import { authenticate } from "../shopify.server";
 
 export const loader = async ({ request }) => {
-  const { session } = await shopify.authenticate.admin(request);
+  const { session } = await authenticate.admin(request);
 
   return json({ shop: session.shop.replace(".myshopify.com", "") });
 };
 
 export async function action({ request }) {
-  const { admin } = await shopify.authenticate.admin(request);
+  const { admin } = await authenticate.admin(request);
 
   const color = ["Red", "Orange", "Yellow", "Green"][
     Math.floor(Math.random() * 4)
@@ -86,7 +86,7 @@ export default function Index() {
   );
   useEffect(() => {
     if (productId) {
-      window?.shopify.toast.show("Product created");
+      shopify.toast.show("Product created");
     }
   }, [productId]);
 

--- a/app/routes/app.jsx
+++ b/app/routes/app.jsx
@@ -3,12 +3,12 @@ import { Outlet, useLoaderData, useRouteError } from "@remix-run/react";
 import { AppProvider as PolarisAppProvider } from "@shopify/polaris";
 import polarisStyles from "@shopify/polaris/build/esm/styles.css";
 
-import { shopify } from "../shopify.server";
+import { authenticate } from "../shopify.server";
 
 export const links = () => [{ rel: "stylesheet", href: polarisStyles }];
 
 export async function loader({ request }) {
-  await shopify.authenticate.admin(request);
+  await authenticate.admin(request);
 
   return json({
     polarisTranslations: require(`@shopify/polaris/locales/en.json`),

--- a/app/routes/auth.$.jsx
+++ b/app/routes/auth.$.jsx
@@ -1,7 +1,7 @@
-import { shopify } from "../shopify.server";
+import { authenticate } from "../shopify.server";
 
 export async function loader({ request }) {
-  await shopify.authenticate.admin(request);
+  await authenticate.admin(request);
 
   return null;
 }

--- a/app/routes/auth.login/error.server.jsx
+++ b/app/routes/auth.login/error.server.jsx
@@ -4,9 +4,9 @@ export function loginErrorMessage(loginErrors) {
   if (loginErrors) {
     switch (loginErrors.shop) {
       case LoginErrorType.MissingShop:
-        return { errors: "Please enter your shop domain to log in" };
+        return { shop: "Please enter your shop domain to log in" };
       case LoginErrorType.InvalidShop:
-        return { errors: "Please enter a valid shop domain to log in" };
+        return { shop: "Please enter a valid shop domain to log in" };
     }
   }
   return {};

--- a/app/routes/auth.login/route.jsx
+++ b/app/routes/auth.login/route.jsx
@@ -13,13 +13,13 @@ import {
 import { Form, useActionData, useLoaderData } from "@remix-run/react";
 import polarisStyles from "@shopify/polaris/build/esm/styles.css";
 
-import { shopify } from "../../shopify.server";
+import { login } from "../../shopify.server";
 import { loginErrorMessage } from "./error.server";
 
 export const links = () => [{ rel: "stylesheet", href: polarisStyles }];
 
 export async function loader({ request }) {
-  const errors = loginErrorMessage(await shopify.login(request));
+  const errors = loginErrorMessage(await login(request));
 
   return json({
     errors,
@@ -28,7 +28,7 @@ export async function loader({ request }) {
 }
 
 export async function action({ request }) {
-  const errors = loginErrorMessage(await shopify.login(request));
+  const errors = loginErrorMessage(await login(request));
 
   return json({
     errors,
@@ -39,8 +39,8 @@ export default function Auth() {
   const { polarisTranslations } = useLoaderData();
   const loaderData = useLoaderData();
   const actionData = useActionData();
-  const errors = actionData?.errors || loaderData.errors;
   const [shop, setShop] = useState("");
+  const { errors } = actionData || loaderData;
 
   return (
     <PolarisAppProvider i18n={polarisTranslations}>

--- a/app/routes/webhooks.jsx
+++ b/app/routes/webhooks.jsx
@@ -1,8 +1,8 @@
-import { shopify } from "../shopify.server";
+import { authenticate } from "../shopify.server";
 import db from "../db.server";
 
 export const action = async ({ request }) => {
-  const { topic, shop } = await shopify.authenticate.webhook(request);
+  const { topic, shop } = await authenticate.webhook(request);
 
   switch (topic) {
     case "APP_UNINSTALLED":

--- a/app/shopify.server.js
+++ b/app/shopify.server.js
@@ -9,7 +9,7 @@ import { restResources } from "@shopify/shopify-api/rest/admin/2023-07";
 
 import prisma from "./db.server";
 
-export const shopify = shopifyApp({
+const shopify = shopifyApp({
   apiKey: process.env.SHOPIFY_API_KEY,
   apiSecretKey: process.env.SHOPIFY_API_SECRET || "",
   scopes: process.env.SCOPES?.split(","),
@@ -33,3 +33,11 @@ export const shopify = shopifyApp({
     ? { customShopDomains: [process.env.SHOP_CUSTOM_DOMAIN] }
     : {}),
 });
+
+export default shopify;
+export const addResponseHeaders = shopify.addResponseHeaders;
+export const authenticate = shopify.authenticate;
+export const canUseLoginForm = shopify.canUseLoginForm;
+export const login = shopify.login;
+export const registerWebhooks = shopify.registerWebhooks;
+export const sessionStorage = shopify.sessionStorage;


### PR DESCRIPTION
Currently, the `shopify` named export conflicts with the `window.shopify` object used by app bridge.

This PR refactors the exports in the `shopify.server` object so the global object is the default, but other bits and pieces are exported individually to clear up the global `shopify` name for app bridge.