### PR TITLE
Fix issue in error boundary handler

### DIFF
--- a/app/routes/app.jsx
+++ b/app/routes/app.jsx
@@ -45,11 +45,14 @@ export const headers = ({
   errorHeaders,
   parentHeaders,
 }) => {
+  if (errorHeaders && Array.from(errorHeaders.entries()).length > 0) {
+    return errorHeaders;
+  }
+
   // Ensure all of the headers Shopify needs are set for embedded app requests
   return new Headers([
-    ...(actionHeaders ? Array.from(actionHeaders.entries()) : []),
-    ...(loaderHeaders ? Array.from(loaderHeaders.entries()) : []),
-    ...(errorHeaders ? Array.from(errorHeaders.entries()) : []),
     ...(parentHeaders ? Array.from(parentHeaders.entries()) : []),
+    ...(loaderHeaders ? Array.from(loaderHeaders.entries()) : []),
+    ...(actionHeaders ? Array.from(actionHeaders.entries()) : []),
   ]);
 };


### PR DESCRIPTION
This fixes an issue where we were doubling up the headers if we got a loader and error headers object in the same call to the boundary (e.g. by calling `authenticate` twice).