### PR TITLE
Add app bridge types package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,4 +7,7 @@ module.exports = {
     "@remix-run/eslint-config/jest-testing-library",
     "prettier",
   ],
+  rules: {
+    "no-undef": "off",
+  },
 };

--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -1,3 +1,4 @@
+import "@shopify/app-bridge-types";
 import { useEffect } from "react";
 import { json } from "@remix-run/node";
 import {

--- a/app/routes/app.jsx
+++ b/app/routes/app.jsx
@@ -1,3 +1,4 @@
+import "@shopify/app-bridge-types";
 import { json } from "@remix-run/node";
 import { Link, Outlet, useLoaderData, useRouteError } from "@remix-run/react";
 import { AppProvider as PolarisAppProvider } from "@shopify/polaris";

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@remix-run/react": "^1.19.0-pre.0",
     "@remix-run/serve": "^1.19.0-pre.0",
     "@shopify/app": "^0.0.0-nightly-0",
+    "@shopify/app-bridge-types": "^0.0.2",
     "@shopify/cli": "^0.0.0-nightly-0",
     "@shopify/polaris": "^11.1.2",
     "@shopify/shopify-app-remix": "^1.0.0-rc.2",


### PR DESCRIPTION
Closes #140 

Adding the AB types package and importing it in files that use app bridge, and disabling the `no-undef` eslint rule which wrongly claims that `shopify` doesn't exist on the client side.