### PR TITLE
fix(types): include @shopify/app-bridge-types globally

### DIFF
--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -1,4 +1,3 @@
-import "@shopify/app-bridge-types";
 import { useEffect } from "react";
 import { json } from "@remix-run/node";
 import {

--- a/app/routes/app.jsx
+++ b/app/routes/app.jsx
@@ -1,4 +1,3 @@
-import "@shopify/app-bridge-types";
 import { json } from "@remix-run/node";
 import { Link, Outlet, useLoaderData, useRouteError } from "@remix-run/react";
 import { AppProvider as PolarisAppProvider } from "@shopify/polaris";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,9 @@
     "paths": {
       "~/*": ["./app/*"]
     },
+    "types": [
+      "@shopify/app-bridge-types"
+    ],
     "noEmit": true
   }
 }


### PR DESCRIPTION
This PR includes `@shopify/app-bridge-types` globally rather than requiring imports in every file.