### PR TITLE
Use Polaris-to-Remix link translation component

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ In Shopify Remix apps you should avoid using `<a>`. Use `<Link> `from `@remix-ru
 Shopify apps are best when they are embedded into the Shopify Admin. This template is configured that way. If you have a reason to not embed your please make 2 changes:
 
 1. Remove the `<script/>` tag to App Bridge in `/app/routes/app.jsx`
-2. Remove any use of App Bridge APIs (`window.shopify`) from your code. By default, the only place that happens is in `/app/routes/app._index.jsx`
+2. Remove any use of App Bridge APIs (`window.shopify`) from your code
 3. Update the config for shopifyApp in `app/shopify.server.js`. Pass `isEmbedded: false`
 
 ## Benefits

--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 import { json } from "@remix-run/node";
 import {
-  Link,
   useActionData,
   useLoaderData,
   useNavigation,
@@ -18,6 +17,7 @@ import {
   Box,
   Divider,
   List,
+  Link,
 } from "@shopify/polaris";
 
 import { authenticate } from "../shopify.server";
@@ -114,18 +114,18 @@ export default function Index() {
                   <Text variant="bodyMd" as="p">
                     This embedded app template uses{" "}
                     <Link
-                      to="https://shopify.dev/docs/apps/tools/app-bridge"
+                      url="https://shopify.dev/docs/apps/tools/app-bridge"
                       target="_blank"
                     >
                       App Bridge
                     </Link>{" "}
                     interface examples like an{" "}
-                    <Link to="/app/additional">
+                    <Link url="/app/additional">
                       additional page in the app nav
                     </Link>
                     , as well as an{" "}
                     <Link
-                      to="https://shopify.dev/docs/api/admin-graphql"
+                      url="https://shopify.dev/docs/api/admin-graphql"
                       target="_blank"
                     >
                       Admin GraphQL
@@ -142,7 +142,7 @@ export default function Index() {
                     Generate a product with GraphQL and get the JSON output for
                     that product. Learn more about the{" "}
                     <Link
-                      to="https://shopify.dev/docs/api/admin-graphql/latest/mutations/productCreate"
+                      url="https://shopify.dev/docs/api/admin-graphql/latest/mutations/productCreate"
                       target="_blank"
                     >
                       productCreate
@@ -193,7 +193,7 @@ export default function Index() {
                       <Text as="span" variant="bodyMd">
                         Framework
                       </Text>
-                      <Link to="https://remix.run" target="_blank">
+                      <Link url="https://remix.run" target="_blank">
                         Remix
                       </Link>
                     </HorizontalStack>
@@ -202,7 +202,7 @@ export default function Index() {
                       <Text as="span" variant="bodyMd">
                         Database
                       </Text>
-                      <Link to="https://www.prisma.io/" target="_blank">
+                      <Link url="https://www.prisma.io/" target="_blank">
                         Prisma
                       </Link>
                     </HorizontalStack>
@@ -212,12 +212,12 @@ export default function Index() {
                         Interface
                       </Text>
                       <span>
-                        <Link to="https://polaris.shopify.com" target="_blank">
+                        <Link url="https://polaris.shopify.com" target="_blank">
                           Polaris
                         </Link>
                         {", "}
                         <Link
-                          to="https://shopify.dev/docs/apps/tools/app-bridge"
+                          url="https://shopify.dev/docs/apps/tools/app-bridge"
                           target="_blank"
                         >
                           App Bridge
@@ -230,7 +230,7 @@ export default function Index() {
                         API
                       </Text>
                       <Link
-                        to="https://shopify.dev/docs/api/admin-graphql"
+                        url="https://shopify.dev/docs/api/admin-graphql"
                         target="_blank"
                       >
                         GraphQL API
@@ -248,7 +248,7 @@ export default function Index() {
                     <List.Item>
                       Build an{" "}
                       <Link
-                        to="https://shopify.dev/docs/apps/getting-started/build-app-example"
+                        url="https://shopify.dev/docs/apps/getting-started/build-app-example"
                         target="_blank"
                       >
                         {" "}
@@ -259,7 +259,7 @@ export default function Index() {
                     <List.Item>
                       Explore Shopify’s API with{" "}
                       <Link
-                        to="https://shopify.dev/docs/apps/tools/graphiql-admin-api"
+                        url="https://shopify.dev/docs/apps/tools/graphiql-admin-api"
                         target="_blank"
                       >
                         GraphiQL

--- a/app/routes/app.additional.jsx
+++ b/app/routes/app.additional.jsx
@@ -1,8 +1,8 @@
-import { Link } from "@remix-run/react";
 import {
   Box,
   Card,
   Layout,
+  Link,
   List,
   Page,
   Text,
@@ -22,7 +22,7 @@ export default function AdditionalPage() {
                 demonstrates how to create multiple pages within app navigation
                 using{" "}
                 <Link
-                  to="https://shopify.dev/docs/apps/tools/app-bridge"
+                  url="https://shopify.dev/docs/apps/tools/app-bridge"
                   target="_blank"
                 >
                   App Bridge
@@ -47,7 +47,7 @@ export default function AdditionalPage() {
               <List spacing="extraTight">
                 <List.Item>
                   <Link
-                    to="https://shopify.dev/docs/apps/design-guidelines/navigation#app-nav"
+                    url="https://shopify.dev/docs/apps/design-guidelines/navigation#app-nav"
                     target="_blank"
                   >
                     App nav best practices

--- a/app/routes/app.jsx
+++ b/app/routes/app.jsx
@@ -1,9 +1,9 @@
+import React from "react";
 import { json } from "@remix-run/node";
 import { Link, Outlet, useLoaderData, useRouteError } from "@remix-run/react";
 import { AppProvider as PolarisAppProvider } from "@shopify/polaris";
 import polarisStyles from "@shopify/polaris/build/esm/styles.css";
 import { boundary } from "@shopify/shopify-app-remix";
-import { RemixPolarisLink } from "@shopify/shopify-app-remix/components";
 
 import { authenticate } from "../shopify.server";
 
@@ -13,14 +13,13 @@ export async function loader({ request }) {
   await authenticate.admin(request);
 
   return json({
-    polarisTranslations: require(`@shopify/polaris/locales/en.json`),
+    polarisTranslations: require("@shopify/polaris/locales/en.json"),
     apiKey: process.env.SHOPIFY_API_KEY,
   });
 }
 
 export default function App() {
-  const { polarisTranslations } = useLoaderData();
-  const { apiKey } = useLoaderData();
+  const { apiKey, polarisTranslations } = useLoaderData();
 
   return (
     <>
@@ -43,6 +42,13 @@ export default function App() {
     </>
   );
 }
+
+/** @type {any} */
+const RemixPolarisLink = React.forwardRef((/** @type {any} */ props, ref) => (
+  <Link {...props} to={props.url ?? props.to} ref={ref}>
+    {props.children}
+  </Link>
+));
 
 // Shopify needs Remix to catch some thrown responses, so that their headers are included in the response.
 export function ErrorBoundary() {

--- a/app/routes/app.jsx
+++ b/app/routes/app.jsx
@@ -3,6 +3,7 @@ import { Link, Outlet, useLoaderData, useRouteError } from "@remix-run/react";
 import { AppProvider as PolarisAppProvider } from "@shopify/polaris";
 import polarisStyles from "@shopify/polaris/build/esm/styles.css";
 import { boundary } from "@shopify/shopify-app-remix";
+import { RemixPolarisLink } from "@shopify/shopify-app-remix/components";
 
 import { authenticate } from "../shopify.server";
 
@@ -28,10 +29,15 @@ export default function App() {
         data-api-key={apiKey}
       />
       <ui-nav-menu>
-        <Link to="/app" rel="home">Home</Link>
+        <Link to="/app" rel="home">
+          Home
+        </Link>
         <Link to="/app/additional">Additional page</Link>
       </ui-nav-menu>
-      <PolarisAppProvider i18n={polarisTranslations}>
+      <PolarisAppProvider
+        i18n={polarisTranslations}
+        linkComponent={RemixPolarisLink}
+      >
         <Outlet />
       </PolarisAppProvider>
     </>


### PR DESCRIPTION
This PR uses a link translation object to allow using Polaris `Link`s in embedded apps.