### PR TITLE
Enable enable-pre-post-scripts for pnpm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 engine-strict=true
 auto-install-peers=true
 shamefully-hoist=true
+enable-pre-post-scripts=true


### PR DESCRIPTION
The default behaviour for npm and yarn is to automatically run pre and post scripts (i.e., if you run `dev` they'll run `predev` if it exists)

This is not the default behaviour for pnpm, and since we have a `predev` script, this will enable it for pnpm.