### PR TITLE
Fix pnpm setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ npm run dev
 Using pnpm:
 
 ```shell
-pnpm run setup
 pnpm run dev
 ```
 


### PR DESCRIPTION
Fixing pnpm instructions, since we no longer need to manually run `setup` before running `dev` the first time.