### PR TITLE
Typo .tsx should be .jsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ export async function loader({ request }) {
 This template come preconfigured with examples of:
 
 1. Setting up your Shopify app in [/app/shopify.server.js](https://github.com/Shopify/shopify-app-template-remix/blob/main/app/shopify.server.js)
-2. Querying data using Graphql. Please see: [/app/routes/app.\_index.tsx](https://github.com/Shopify/shopify-app-template-remix/blob/main/app/routes/app._index.jsx).
+2. Querying data using Graphql. Please see: [/app/routes/app.\_index.jsx](https://github.com/Shopify/shopify-app-template-remix/blob/main/app/routes/app._index.jsx).
 3. Responding to mandatory webhooks in [/app/routes/webhooks.jsx](https://github.com/Shopify/shopify-app-template-remix/blob/main/app/routes/webhooks.jsx)
 
 Please read the [documentation for @shopify/shopify-app-remix](https://www.npmjs.com/package/@shopify/shopify-app-remix#authenticating-admin-requests) to understand what other API's are available.


### PR DESCRIPTION
Super minor, but confused me for a minute when working through the steps.

/app/routes/app._index.tsx => /app/routes/app._index.jsx