### PR TITLE
Remove waiting for response label on comment creation

### DIFF
--- a/.github/workflows/remove-labels-on-activity.yml
+++ b/.github/workflows/remove-labels-on-activity.yml
@@ -1,0 +1,15 @@
+name: Remove Waiting Labels
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+jobs:
+  remove-labels-on-activity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-remove-labels@v1
+        if: contains(github.event.issue.labels.*.name, 'Waiting for Response')
+        with:
+          labels: |
+            Waiting for Response


### PR DESCRIPTION
When we request a response from partners, we also add a `Waiting for response` labels. This workflow will automatically remove that label when a comment is created on the issue so we get notified.