### PR TITLE
Remove reference to script tag that is now abstracted

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ In Shopify Remix apps you should avoid using `<a>`. Use `<Link> `from `@remix-ru
 
 Shopify apps are best when they are embedded into the Shopify Admin. This template is configured that way. If you have a reason to not embed your please make 2 changes:
 
-1. Remove the `<script/>` tag to App Bridge in `/app/routes/app.jsx`
+1. Change the `isEmbeddedApp` prop to false for the `AppProvider` in `/app/routes/app.jsx`
 2. Remove any use of App Bridge APIs (`window.shopify`) from your code
 3. Update the config for shopifyApp in `app/shopify.server.js`. Pass `isEmbeddedApp: false`
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #329 

### WHAT is this pull request doing?

In an earlier version of the template we include the script tag in the template.  But then we released [1.1.0](https://github.com/Shopify/shopify-app-js/blob/main/packages/shopify-app-remix/CHANGELOG.md#110) which includes a Provider that abstracts this script tag (amongst other things).  But we forgot to update these docs.

So here I update these docs.

### Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- ~~[ ] I have added/updated tests for this change~~
- [x] I have made changes to the `README.md` file and other related documentation, if applicable
