### PR TITLE
Simplify navigation using App Bridge

### DIFF
--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -1,11 +1,6 @@
 import { useEffect } from "react";
 import { json } from "@remix-run/node";
-import {
-  useActionData,
-  useLoaderData,
-  useNavigation,
-  useSubmit,
-} from "@remix-run/react";
+import { useActionData, useNavigation, useSubmit } from "@remix-run/react";
 import {
   Page,
   Layout,
@@ -23,9 +18,9 @@ import {
 import { authenticate } from "../shopify.server";
 
 export const loader = async ({ request }) => {
-  const { session } = await authenticate.admin(request);
+  await authenticate.admin(request);
 
-  return json({ shop: session.shop.replace(".myshopify.com", "") });
+  return null;
 };
 
 export async function action({ request }) {
@@ -75,7 +70,6 @@ export async function action({ request }) {
 
 export default function Index() {
   const nav = useNavigation();
-  const { shop } = useLoaderData();
   const actionData = useActionData();
   const submit = useSubmit();
 
@@ -153,7 +147,7 @@ export default function Index() {
                 <HorizontalStack gap="3" align="end">
                   {actionData?.product && (
                     <Button
-                      url={`https://admin.shopify.com/store/${shop}/admin/products/${productId}`}
+                      url={`shopify:admin/products/${productId}`}
                       target="_blank"
                     >
                       View product


### PR DESCRIPTION
### WHY are these changes introduced?

We don't need to parse the `session.shop` in the loader just to then construct a URL in the component.  Instead, we can use [App Bridge](https://shopify.dev/docs/api/app-bridge-library/reference/navigation#navigating-to-pages-in-the-shopify-admin-/products-page-with-resource)

### WHAT is this pull request doing?

1. Remove the logic from the loader.  I kept `shopify.authenticate` just because I think it's one of the first things users will want to mess with, but technically it doesn't need to be there because we have the layout.
2. Update the product URL to App Bridge's special schema

### Testing

1. Click generate a product
2. Click View product.

The product should open in a new tab.

### Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- ~~[ ] I have added/updated tests for this change~~
- ~~[ ] I have made changes to the `README.md` file and other related documentation, if applicable~~
