### PR TITLE
Fix docker env var setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN npm install
 RUN npm run build
 
 # You'll probably want to remove this in production, it's here to make it easier to test things!
-RUN rm prisma/dev.sqlite
-RUN npx prisma migrate dev --name init
+RUN rm -f prisma/dev.sqlite
 
-CMD ["npm", "run", "start"]
+CMD ["npm", "run", "docker-start"]

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "config:use": "shopify app config use",
     "env": "shopify app env",
     "start": "remix-serve build",
+    "docker-start": "prisma migrate deploy && remix-serve build",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "shopify": "shopify",
     "prisma": "prisma",


### PR DESCRIPTION
### WHY are these changes introduced?

As we found out in #327, our current Dockerfile set up doesn't allow using env vars in the Prisma schema file, which makes it hard to set up.

### WHAT is this pull request doing?

Moving the db migration from the build phase to the `RUN` command, so it runs with the env vars in Heroku.