### PR TITLE
Link to the shopify.dev docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 This is a template for building a [Shopify app](https://shopify.dev/docs/apps/getting-started) using the [Remix](https://remix.run) framework.
 
-<!-- TODO: Uncomment this after we've started using the template in the CLI -->
-<!-- Rather than cloning this repo, you can use your preferred package manager and the Shopify CLI with [these steps](#installing-the-template). -->
+Rather than cloning this repo, you can use your preferred package manager and the Shopify CLI with [these steps](#installing-the-template).
+
+Visit the [`shopify.dev` documentation](https://shopify.dev/docs/api/shopify-app-remix) for more details on the Remix app package.
 
 ## Quick start
 
@@ -12,8 +13,6 @@ This is a template for building a [Shopify app](https://shopify.dev/docs/apps/ge
 1. You must [download and install Node.js](https://nodejs.org/en/download/) if you don't already have it.
 2. You must [create a Shopify partner account](https://partners.shopify.com/signup) if you don’t have one.
 3. You must create a store for testing if you don't have one, either a [development store](https://help.shopify.com/en/partners/dashboard/development-stores#create-a-development-store) or a [Shopify Plus sandbox store](https://help.shopify.com/en/partners/dashboard/managing-stores/plus-sandbox-store).
-
-<!-- TODO Make this section about using @shopify/app once it's added to the CLI. -->
 
 ### Setup
 


### PR DESCRIPTION
This PR just adds a link to the docs on shopify.dev to the README file.