### PR TITLE
Improve webhooks route

### DIFF
--- a/app/routes/webhooks.jsx
+++ b/app/routes/webhooks.jsx
@@ -2,7 +2,13 @@ import { authenticate } from "../shopify.server";
 import db from "../db.server";
 
 export const action = async ({ request }) => {
-  const { topic, shop, session } = await authenticate.webhook(request);
+  const { topic, shop, session, admin, payload } = await authenticate.webhook(
+    request
+  );
+  if (!admin) {
+    // The admin context isn't returned if the webhook fired after a shop was uninstalled.
+    throw new Response();
+  }
 
   switch (topic) {
     case "APP_UNINSTALLED":


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, the webhooks route works, but it doesn't show two relevant pieces of information:

- that the `payload` is returned as part of the context object
- that the `admin` context might not be present (e.g. if a shop uninstalled the app)

### WHAT is this pull request doing?

Updating the template route to show off those things.