### PR TITLE
Add unit/component and end-to-end testing to template using Vitest, Testing-Library, @remix-run/testing, and Playwright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ database.sqlite
 .env
 package-lock.json
 yarn.lock
+/tests/e2e/results/
+/tests/e2e/reports/
+/playwright/.cache/

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
     "vite-tsconfig-paths": "^4.3.1"
   },
   "devDependencies": {
-    "@playwright/test": "^1.39.0",
+    "@playwright/test": "^1.42.1",
     "@remix-run/eslint-config": "^2.7.1",
+    "@remix-run/testing": "^2.7.1",
     "@shopify/api-codegen-preset": "^0.0.3",
     "@shopify/app-bridge-types": "^0.0.7",
-    "@remix-run/testing": "^2.0.0",
     "@shopify/shopify-app-session-storage-memory": "^2.0.0",
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "vite-tsconfig-paths": "^4.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.39.0",
     "@remix-run/eslint-config": "^2.7.1",
     "@shopify/api-codegen-preset": "^0.0.3",
     "@shopify/app-bridge-types": "^0.0.7",
@@ -53,6 +54,7 @@
     "@vitejs/plugin-react": "^4.1.0",
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^9.1.0",
+    "jose": "^4.15.2",
     "jsdom": "^22.1.0",
     "prettier": "^3.2.4",
     "typescript": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -41,15 +41,24 @@
     "@remix-run/eslint-config": "^2.7.1",
     "@shopify/api-codegen-preset": "^0.0.3",
     "@shopify/app-bridge-types": "^0.0.7",
+    "@remix-run/testing": "^2.0.0",
+    "@shopify/shopify-app-session-storage-memory": "^2.0.0",
+    "@testing-library/jest-dom": "^6.1.4",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.5.1",
     "@types/eslint": "^8.40.0",
     "@types/node": "^20.6.3",
     "@types/react": "^18.2.31",
     "@types/react-dom": "^18.2.14",
+    "@vitejs/plugin-react": "^4.1.0",
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^9.1.0",
+    "jsdom": "^22.1.0",
     "prettier": "^3.2.4",
     "typescript": "^5.2.2",
-    "vite": "^5.1.3"
+    "vite": "^5.1.3",
+    "vite-tsconfig-paths": "^4.2.1",
+    "vitest": "^0.34.6"
   },
   "workspaces": {
     "packages": [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,117 @@
+import { defineConfig, devices } from '@playwright/test';
+import dotenv from "dotenv";
+import path from "node:path";
+
+dotenv.config({
+  path: path.resolve(__dirname, "./tests/test-utilities/test.env"),
+});
+
+if (
+  process.env.SHOPIFY_API_KEY === undefined ||
+  process.env.SHOPIFY_API_SECRET === undefined ||
+  process.env.SHOPIFY_APP_URL === undefined||
+  process.env.SCOPES === undefined
+) {
+  throw new Error("Test environment variables not set");
+}
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  // Look for test files in the "./tests/e2e" directory, relative to this configuration file.
+  testDir: './tests/e2e',
+
+  // Each test is given 30 seconds.
+  timeout: 30 * 1000,
+
+  // Maximum time expect() should wait for the condition to be met.
+  expect: {
+		timeout: 5 * 1000,
+	},
+
+  // Run all tests in parallel.
+  fullyParallel: true,
+
+  // Fail the build on CI if you accidentally left test.only in the source code.
+  forbidOnly: !!process.env.CI,
+
+  // Retry on CI only.
+  retries: process.env.CI ? 2 : 0,
+
+  // Opt out of parallel tests on CI.
+  workers: process.env.CI ? 1 : undefined,
+
+  // Reporter to use. See https://playwright.dev/docs/test-reporters 
+  reporter: [
+    ['list'],
+    // ['html', { outputFolder: './tests/e2e/reports' }],
+  ],
+
+  // Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions.
+  use: {
+    // Base URL to use in actions like `await page.goto('/')`.
+    baseURL: 'http://127.0.0.1:3000',
+
+    // Collect trace when retrying the failed test.
+    trace: 'on-first-retry',
+  },
+
+  // Configure projects for major browsers.
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  // Run your local dev server before starting the tests.
+  webServer: [
+    {
+      command: 'npx remix build && npm run start',
+      url: 'http://127.0.0.1:3000',
+      timeout: 120 * 1000,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        "SHOPIFY_APP_URL": process.env.SHOPIFY_APP_URL,
+        "SHOPIFY_API_KEY": process.env.SHOPIFY_API_KEY,
+        "SHOPIFY_API_SECRET": process.env.SHOPIFY_API_SECRET,
+        "SCOPES": process.env.SCOPES,
+        "PORT": process.env.PORT || "3000",
+      },
+    },
+  ],
+  outputDir: "./tests/e2e/results",
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig, devices } from '@playwright/test';
 import dotenv from "dotenv";
+import url from "node:url";
 import path from "node:path";
+
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 dotenv.config({
   path: path.resolve(__dirname, "./tests/test-utilities/test.env"),
@@ -98,7 +102,7 @@ export default defineConfig({
   // Run your local dev server before starting the tests.
   webServer: [
     {
-      command: 'npx remix build && npm run start',
+      command: 'npm run build && npm run start',
       url: 'http://127.0.0.1:3000',
       timeout: 120 * 1000,
       reuseExistingServer: !process.env.CI,

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,44 @@
+# Testing Shopify App Template - Remix
+
+This is a template for testing [Shopify apps](https://shopify.dev/docs/apps/getting-started) built using the [Remix](https://remix.run) framework.
+
+This template demonstrates how to use Vitest, Testing Library, and `@remix-run/testing` to test routes and components built with Polaris components, and how to use Playwright to do end-to-end testing for Shopify apps.
+
+## Quick start
+
+### Prerequisites
+You must [initialise a Remix app using the Shopify CLI](https://shopify.dev/docs/apps/getting-started/create).
+
+### Setup
+Run `npm init playwright`, choose `test/e2e` as your test folder when asked, and don't overwrite `playwright.config.ts` when prompted.
+
+### Route and component testing
+1. From your command line, run `npx vitest` to test routes and components.
+
+`/tests/routes/AdditionalPage.test.jsx` provides an example test. You can duplicate the `tests/routes` directory if you wish to organise your test files in multiple directories.
+
+### End-to-end testing
+1. Run `npm run predev`.
+1. From your command line, run `npx playwright test` for end-to-end testing.
+
+`example.test.ts` provides an example test. You can duplicate this file if you wish to add additional tests.
+
+## (In)frequently Asked Questions
+- What is `@testing-library/polaris`?
+
+  `@testing-library/polaris` is not a real package. It is a Vitest alias and TypeScript path set up in config files for convenience.
+
+- Why are you using Vitest workspaces?
+
+  Vitest workspaces contain the `@testing-library/polaris` alias and the Shopify mocks to the directories with Polaris and Shopify tests.
+
+- Why do I need to run `npm run predev`?
+
+  In a Shopify Remix app project, `npm run dev` and `npm run shopify dev` apply Prisma migrations. If you haven't yet run either of these commands in your project, you need to manually apply the Prisma migrations by running `npm run predev` before running Playwright. 
+
+## Resources
+- [Vitest](https://vitest.dev/guide/)
+- [Remix testing](https://testing.epicweb.dev/07)
+- [Testing Library](https://testing-library.com/docs/learning/)
+- [Testing Library Vitest/Jest matchers](https://github.com/testing-library/jest-dom#custom-matchers)
+- [Playwright](https://playwright.dev/docs/intro)

--- a/tests/e2e/example.test.ts
+++ b/tests/e2e/example.test.ts
@@ -1,0 +1,144 @@
+import { test as base, expect } from '@playwright/test';
+import { sessionStorage } from '~/shopify.server';
+import { Session } from '@shopify/shopify-api';
+import dotenv from "dotenv";
+import path from "node:path";
+import { SignJWT } from "jose";
+
+dotenv.config({
+  path: path.resolve(__dirname, "../test-utilities/test.env")
+});
+
+
+function getHMACKey(key: string) {
+  const arrayBuffer = new Uint8Array(key.length);
+  for (let i = 0, keyLen = key.length; i < keyLen; i++) {
+    arrayBuffer[i] = key.charCodeAt(i);
+  }
+
+  return arrayBuffer;
+}
+
+/**
+ * https://github.com/Shopify/shopify-app-js/blob/7ce48d488a452924cd9ca3ffffab02543a880027/packages/shopify-app-remix/src/server/authenticate/admin/authenticate.ts#L137
+ * https://github.com/Shopify/shopify-app-js/blob/main/packages/shopify-app-remix/src/server/authenticate/helpers/validate-session-token.ts#L9
+ * https://github.com/Shopify/shopify-api-js/blob/main/packages/shopify-api/lib/session/decode-session-token.ts#L15
+ * https://github.com/Shopify/shopify-api-js/blob/main/packages/shopify-api/lib/utils/get-hmac-key.ts
+ * https://github.com/panva/jose/blob/HEAD/docs/functions/jwt_verify.jwtVerify.md
+ * https://github.com/Shopify/shopify-app-js/blob/main/packages/shopify-app-remix/src/server/authenticate/admin/authenticate.ts#L434
+ * https://github.com/Shopify/shopify-api-js/blob/main/packages/shopify-api/lib/session/session-utils.ts#L16
+ * https://github.com/Shopify/shopify-app-js/blob/main/packages/shopify-app-remix/src/server/authenticate/admin/authenticate.ts#L454
+ */
+
+const test = base.extend<{
+  mockShopifyAuthentication: void,
+  handleShopifyRedirects: void,
+}>({
+  mockShopifyAuthentication: [
+    async ({ page }, use) => {
+    if (
+      process.env.SHOPIFY_API_KEY === undefined ||
+      process.env.SHOPIFY_API_SECRET === undefined ||
+      process.env.SHOPIFY_APP_URL === undefined ||
+      process.env.SCOPES === undefined ||
+      process.env.TEST_PARALLEL_INDEX === undefined
+    ) {
+      throw new Error("Test environment variables not set");
+    }
+
+    const apiKey = process.env.SHOPIFY_API_KEY;
+    const apiSecretKey = process.env.SHOPIFY_API_SECRET;
+    const scopes = process.env.SCOPES;
+    const appUrl = new URL(process.env.SHOPIFY_APP_URL
+        .replace("://", "://" + process.env.TEST_PARALLEL_INDEX));
+
+    sessionStorage.storeSession(new Session({
+      id: "offline_" + appUrl.hostname, // online or offline ID
+      shop: appUrl.hostname,
+      state: "", // OAuth Cookie state
+      isOnline: false, // true for online
+      scope: scopes, 
+      // expires: undefined,
+      accessToken: "true",
+    }));
+
+    const jwt = await new SignJWT({
+        dest: appUrl.toString(),
+        sid: apiKey + "0", // Session ID = JWT Audience + JWT Subject
+      })
+        .setIssuer(new URL("/admin", appUrl).toString())
+        .setAudience(apiKey)
+        .setSubject("0") // JWT Subject is Merchant staff ID; used for Online Token
+        .setExpirationTime("60m")
+        .setNotBefore("0m")
+        .setIssuedAt()
+        .setJti(Math.random().toString(32).slice(2))
+        .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+        .sign(getHMACKey(apiSecretKey));
+    
+    await page.setExtraHTTPHeaders({
+      origin: appUrl.toString(),
+      authorization: "Bearer " + jwt,
+    });
+
+    await use();
+
+    sessionStorage.deleteSession("offline_" + appUrl.hostname); // online or offline ID
+  }, { auto: true }],
+
+  handleShopifyRedirects: [
+    async ({ page, baseURL }, use) => {
+    if (
+      process.env.SHOPIFY_APP_URL === undefined ||
+      process.env.TEST_PARALLEL_INDEX === undefined
+    ) {
+      throw new Error("Test environment variables not set");
+    }
+
+    const appUrl = process.env.SHOPIFY_APP_URL;
+
+    await page.route(baseURL + "/**/*", async route => {
+      const response = await route.fetch({ maxRedirects: 0 });
+      const responseHeaders = response.headers();
+      let redirectHeader = "";
+
+      if (
+        response.status() === 204 && // Remix redirect response
+        responseHeaders["x-remix-redirect"].includes(appUrl) // wrong redirect URL
+      ) {
+        redirectHeader = "x-remix-redirect";
+      } else if (
+        response.status().toString().charAt(0) === "3" && // redirect response
+        responseHeaders.location.includes(appUrl) // wrong redirect URL
+      ) {
+        redirectHeader = "location";
+      }
+
+      if (redirectHeader.length > 0) {
+        const shopifyLocation = new URL(responseHeaders[redirectHeader]);
+        const pathname = shopifyLocation.pathname;
+        const location = new URL(pathname, baseURL).toString();
+        route.fulfill({
+          response,
+          headers: {
+            ...responseHeaders,
+            [redirectHeader]: location,
+          },
+        });
+      } else {
+        route.fulfill({ response });
+      }
+    });
+
+    await use();
+
+  }, { auto: true }],
+});
+
+test("Can load", async ({ page }) => {
+  await page.goto("/app/");
+
+  const h3Heading = page.getByRole("heading", { level: 3, });
+  await expect(h3Heading).toBeVisible();
+  await expect(h3Heading).toContainText("Get started with products");
+});

--- a/tests/e2e/example.test.ts
+++ b/tests/e2e/example.test.ts
@@ -3,7 +3,11 @@ import { sessionStorage } from '~/shopify.server';
 import { Session } from '@shopify/shopify-api';
 import dotenv from "dotenv";
 import path from "node:path";
+import url from "node:url";
 import { SignJWT } from "jose";
+
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 dotenv.config({
   path: path.resolve(__dirname, "../test-utilities/test.env")

--- a/tests/routes/AdditionalPage.test.jsx
+++ b/tests/routes/AdditionalPage.test.jsx
@@ -1,0 +1,24 @@
+import { beforeEach, test, expect } from 'vitest';
+import { render, screen } from '@testing-library/polaris';
+import { unstable_createRemixStub as createRemixStub } from '@remix-run/testing';
+import AdditionalPage from '~/routes/app.additional';
+
+let App;
+
+beforeEach(() => {
+  App = createRemixStub([
+    {
+      path: '/',
+      Component: AdditionalPage,
+      action: () => null,
+    },
+  ]);
+});
+
+test('Can test exported Remix route/component containing Polaris components', async () => {
+  render(<App initialEntries={['/']} />);
+  const list = await screen.getByRole('list');
+  const listItem = await screen.getByRole('listitem');
+  screen.debug();
+  expect(list).toContainElement(listItem);
+});

--- a/tests/routes/AdditionalPage.test.tsx
+++ b/tests/routes/AdditionalPage.test.tsx
@@ -1,9 +1,9 @@
 import { beforeEach, test, expect } from 'vitest';
 import { render, screen } from '@testing-library/polaris';
-import { unstable_createRemixStub as createRemixStub } from '@remix-run/testing';
+import { createRemixStub } from '@remix-run/testing';
 import AdditionalPage from '~/routes/app.additional';
 
-let App;
+let App: ReturnType<typeof createRemixStub>;
 
 beforeEach(() => {
   App = createRemixStub([

--- a/tests/routes/tsconfig.json
+++ b/tests/routes/tsconfig.json
@@ -1,6 +1,7 @@
 {
-    "extends": "../../tsconfig.json",
-    "include": ["./**/*.js", "./**/*.jsx"],
+  "extends": "../../tsconfig.json",
+  "include": ["./**/*.js", "./**/*.jsx"],
+  "compilerOptions": {
     "paths": {
       "~/*": ["./app/*"],
       "@testing-library/polaris": [
@@ -8,3 +9,4 @@
       ]
     }
   }  
+}

--- a/tests/routes/tsconfig.json
+++ b/tests/routes/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.json",
+    "include": ["./**/*.js", "./**/*.jsx"],
+    "paths": {
+      "~/*": ["./app/*"],
+      "@testing-library/polaris": [
+        "./tests/test-utilities/testing-library-polaris"
+      ]
+    }
+  }  

--- a/tests/routes/tsconfig.json
+++ b/tests/routes/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["./**/*.js", "./**/*.jsx"],
   "compilerOptions": {
     "paths": {
       "~/*": ["./app/*"],

--- a/tests/routes/vitest.config.ts
+++ b/tests/routes/vitest.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import rootConfig from '../../vitest.config';
+import path from 'node:path';
+
+export default mergeConfig(
+  rootConfig,
+  defineConfig({
+    test: {
+      environment: 'jsdom',
+      include: ['*.test.?(c|m)[jt]s?(x)', '**/*.test.?(c|m)[jt]s?(x)'],
+      setupFiles: [
+        '../test-utilities/shopify.setup.js',
+        '../test-utilities/testing-library.setup.js',
+      ],
+    },
+    resolve: {
+      alias: {
+        '@testing-library/polaris': path.resolve(
+          __dirname,
+          '../test-utilities/testing-library-polaris.jsx'
+        ),
+      },
+    },
+  })
+);

--- a/tests/test-utilities/mock-shopify-app-remix.js
+++ b/tests/test-utilities/mock-shopify-app-remix.js
@@ -1,29 +1,44 @@
-import { LATEST_API_VERSION, LogSeverity } from '@shopify/shopify-api';
-import { MemorySessionStorage } from '@shopify/shopify-app-session-storage-memory';
+import { LATEST_API_VERSION as apiVersion } from '@shopify/shopify-api';
+import {
+  MemorySessionStorage,
+} from '@shopify/shopify-app-session-storage-memory';
 import { vi } from 'vitest';
 
-const API_SECRET_KEY = 'testApiSecretKey';
-const API_KEY = 'testApiKey';
-const APP_URL = 'https://my-test-app.myshopify.io';
+import dotenv from "dotenv";
+import path from "node:path";
 
-function testConfig(overrides = {}) {
+dotenv.config({
+  path: path.resolve(__dirname, "../test-utilities/test.env"),
+});
+
+if (
+  process.env.SHOPIFY_API_KEY === undefined ||
+  process.env.SHOPIFY_API_SECRET === undefined ||
+  process.env.SHOPIFY_APP_URL === undefined||
+  process.env.SCOPES === undefined
+) {
+  throw new Error("Test environment variables not set");
+}
+
+const apiKey = process.env.SHOPIFY_API_KEY;
+const apiSecretKey = process.env.SHOPIFY_API_SECRET;
+const appUrl = process.env.SHOPIFY_APP_URL;
+const scopes = process.env.SCOPES;
+
+const testConfig = function testConfig(overrides = {}) { // assignment to avoid hoisting
   return {
-    apiKey: API_KEY,
-    apiSecretKey: API_SECRET_KEY,
-    scopes: ['testScope'],
-    apiVersion: LATEST_API_VERSION,
-    appUrl: APP_URL,
-    logger: {
-      log: vi.fn(),
-      level: LogSeverity.Debug,
-    },
-    isEmbeddedApp: true,
+    apiKey,
+    apiSecretKey,
+    scopes: scopes.split(","),
+    apiVersion,
+    appUrl,
     sessionStorage: new MemorySessionStorage(),
     ...overrides,
   };
-}
+};
 
 vi.mock('@shopify/shopify-app-remix', async () => {
+  /** @type {import("@shopify/shopify-app-remix")} */
   const shopify = await vi.importActual('@shopify/shopify-app-remix');
 
   return {

--- a/tests/test-utilities/mock-shopify-app-remix.js
+++ b/tests/test-utilities/mock-shopify-app-remix.js
@@ -1,0 +1,37 @@
+import { LATEST_API_VERSION, LogSeverity } from '@shopify/shopify-api';
+import { MemorySessionStorage } from '@shopify/shopify-app-session-storage-memory';
+import { vi } from 'vitest';
+
+const API_SECRET_KEY = 'testApiSecretKey';
+const API_KEY = 'testApiKey';
+const APP_URL = 'https://my-test-app.myshopify.io';
+
+function testConfig(overrides = {}) {
+  return {
+    apiKey: API_KEY,
+    apiSecretKey: API_SECRET_KEY,
+    scopes: ['testScope'],
+    apiVersion: LATEST_API_VERSION,
+    appUrl: APP_URL,
+    logger: {
+      log: vi.fn(),
+      level: LogSeverity.Debug,
+    },
+    isEmbeddedApp: true,
+    sessionStorage: new MemorySessionStorage(),
+    ...overrides,
+  };
+}
+
+vi.mock('@shopify/shopify-app-remix', async () => {
+  const shopify = await vi.importActual('@shopify/shopify-app-remix');
+
+  return {
+    ...shopify,
+    shopifyApp: () => shopify.shopifyApp(testConfig()),
+    boundary: {
+      error: shopify.boundary.error,
+      headers: shopify.boundary.headers,
+    },
+  };
+});

--- a/tests/test-utilities/shopify.setup.js
+++ b/tests/test-utilities/shopify.setup.js
@@ -1,0 +1,16 @@
+import './mock-shopify-app-remix';
+import { vi } from "vitest";
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // deprecated
+    removeListener: vi.fn(), // deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});

--- a/tests/test-utilities/test.env
+++ b/tests/test-utilities/test.env
@@ -1,0 +1,4 @@
+SHOPIFY_APP_URL="http://my-test-app.myshopify.io"
+SHOPIFY_API_KEY="testApiKey"
+SHOPIFY_API_SECRET="testApiSecretKey"
+SCOPES="testScope"

--- a/tests/test-utilities/testing-library-polaris.jsx
+++ b/tests/test-utilities/testing-library-polaris.jsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+import { PolarisTestProvider } from '@shopify/polaris';
+import translations from '@shopify/polaris/locales/en.json';
+
+/** @param {{ children: import("react").ReactElement }} args */
+function ShopifyAppProvider({ children }) {
+  return (
+    <PolarisTestProvider i18n={translations}>{children}</PolarisTestProvider>
+  );
+}
+
+/**
+ *
+ * @param {import("react").ReactElement} ui
+ * @param {import("@testing-library/react").RenderOptions} [options]
+ * @returns
+ */
+const shopifyRender = (ui, options) =>
+  render(ui, { wrapper: ShopifyAppProvider, ...options });
+
+// re-export everything
+export * from '@testing-library/react';
+
+// override render method
+export { shopifyRender as render };

--- a/tests/test-utilities/testing-library.setup.js
+++ b/tests/test-utilities/testing-library.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+/// <reference types="vitest" />
+/// <reference types="vite/client" />
+
+import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [react(), tsconfigPaths()],
+});

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,1 @@
+export default ['tests/*/vitest.config.{ts,js}'];


### PR DESCRIPTION
### WHY are these changes introduced?

Adding component/unit testing to the Shopify Remix template is complicated by the need to use:
1. @remix-run/testing,
2. `<PolarisTestProvider>`, and
3. Mocks for `authenticate.admin(request)` calls.

Adding end-to-end testing to the Shopify Remix template is complicated by the need to use:
1. Mocks for JWT tokens
2. Mocks for sessions in the database

This is especially true for someone unfamiliar with the Shopify codebase.

Adding test utilities and example tests that have solved these problems will increase the number of developers that test their apps, and therefore, the quality of Shopify Remix apps produced.

### WHAT is this pull request doing?

1. Adds Vitest, Testing-Library, @remix-run/testing, and Playwright to the Remix template,
2. Adds test utilities to ease testing the Shopify Remix template
3. Adds example tests