### PR TITLE
ignore engines when converting TS to JS

### DIFF
--- a/.github/workflows/convert-to-js.yml
+++ b/.github/workflows/convert-to-js.yml
@@ -24,7 +24,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn add -W --dev @shopify/prettier-config @shopify/eslint-plugin
+        run: yarn add -W --dev @shopify/prettier-config @shopify/eslint-plugin --ignore-engines
 
       - name: Transpile to Javascript
         run: |


### PR DESCRIPTION
### WHY are these changes introduced?

The Github action is failing due to node versions.

### WHAT is this pull request doing?

add `--ignore-engines` to the `yarn add` command so that it doesn't fail

### Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
