### PR TITLE
Add React type packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "@remix-run/eslint-config": "^2.0.0",
     "@types/eslint": "^8.40.0",
     "@types/node": "^20.6.3",
+    "@types/react": "^18.2.31",
+    "@types/react-dom": "^18.2.14",
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^8.8.0",
     "prettier": "^2.8.8",


### PR DESCRIPTION
### WHY are these changes introduced?

Without these types packages, every JSX element get's red squgglies:

```
Type 'Element' is not assignable to type 'ReactNode'.ts(2322)
```

Adding these packages fixes them.

### WHAT is this pull request doing?

Adds 2 type packages

### Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
