### PR TITLE
Improve JS conversion workflow

### DIFF
--- a/.github/workflows/convert-to-js.yml
+++ b/.github/workflows/convert-to-js.yml
@@ -64,13 +64,16 @@ jobs:
 
       - name: Stage changes to files
         run: |
-          git fetch
-          git checkout javascript_updates || git checkout -b javascript_updates
           git config user.name GitHub
           git config user.email noreply@github.com
-          git add app
+          git fetch
+          git restore --staged package.json
+          git restore package.json
+          git add .
+          git checkout -b temp_javascript_updates
           git commit -m "Convert template to Javascript"
-          git push --force origin javascript_updates
+          git rebase -m -X theirs javascript
+          git push -f origin temp_javascript_updates:javascript_updates
 
       - name: Create Javascript PR
         run: |

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -159,7 +159,6 @@ export default function Index() {
                   <Box
                     padding="400"
                     background="bg-surface-active"
-                    padding="400"
                     borderWidth="025"
                     borderRadius="200"
                     borderColor="border"
@@ -247,7 +246,7 @@ export default function Index() {
                   <Text as="h2" variant="headingMd">
                     Next steps
                   </Text>
-                  <List spacing="extraTight">
+                  <List>
                     <List.Item>
                       Build an{" "}
                       <Link

--- a/app/routes/app.additional.tsx
+++ b/app/routes/app.additional.tsx
@@ -45,7 +45,7 @@ export default function AdditionalPage() {
               <Text as="h2" variant="headingMd">
                 Resources
               </Text>
-              <List spacing="extraTight">
+              <List>
                 <List.Item>
                   <Link
                     url="https://shopify.dev/docs/apps/design-guidelines/navigation#app-nav"


### PR DESCRIPTION
### WHY are these changes introduced?

The JS conversion workflow wasn't properly updating git history, so the PR ended up containing some unwanted history.

### WHAT is this pull request doing?

Changing the process slightly so we always use a fresh local branch, and push that over the `javascript_updates` branch.
