### PR TITLE
Update REST resources API version

### DIFF
--- a/app/shopify.server.ts
+++ b/app/shopify.server.ts
@@ -6,7 +6,7 @@ import {
   LATEST_API_VERSION,
 } from "@shopify/shopify-app-remix/server";
 import { PrismaSessionStorage } from "@shopify/shopify-app-session-storage-prisma";
-import { restResources } from "@shopify/shopify-api/rest/admin/2023-07";
+import { restResources } from "@shopify/shopify-api/rest/admin/2023-10";
 import prisma from "./db.server";
 
 const shopify = shopifyApp({

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@shopify/app-bridge-types": "^0.0.3",
     "@shopify/cli": "^3.48",
     "@shopify/polaris": "^12.0.0",
-    "@shopify/shopify-app-remix": "^2.0.0",
+    "@shopify/shopify-app-remix": "^2.0.2",
     "@shopify/shopify-app-session-storage-prisma": "^2.0.0",
     "cross-env": "^7.0.3",
     "isbot": "latest",


### PR DESCRIPTION
This PR updates the REST resources used by the app to the latest ones, `2023-10`. It also bumps the remix package to the one that uses that as `LATEST_API_VERSION`.