### PR TITLE
Add direct dependency for shopify-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@shopify/app-bridge-types": "^0.0.3",
     "@shopify/cli": "^3.50.0",
     "@shopify/polaris": "^12.0.0",
+    "@shopify/shopify-api": "^8.0.2",
     "@shopify/shopify-app-remix": "^2.1.0",
     "@shopify/shopify-app-session-storage-prisma": "^2.0.0",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #407

`@shopify/shopify-api` needs to be a direct dependency of this project because we're directly importing from it, so we need to make sure the version we end up using matches our expectation.

Not having this breaks when using `pnpm` because `@shopify/app` also has a dependency on the library, but on version 7, which confuses `pnpm`.

### WHAT is this pull request doing?

Adding the dependency.