### PR TITLE
Close issues waiting for response

### DIFF
--- a/.github/workflows/close-waiting-for-response-issues.yml
+++ b/.github/workflows/close-waiting-for-response-issues.yml
@@ -1,0 +1,20 @@
+name: Close Waiting for Response Issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+jobs:
+  check-need-info:
+    runs-on: ubuntu-latest
+    steps:
+      - name: close-issues
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "close-issues"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "Waiting for Response"
+          inactive-day: 14
+          body: |
+            We are closing this issue because we did not hear back regarding additional details we needed to resolve this issue. If the issue persists and you are able to provide the missing clarification we need, you can respond here or create a new issue.
+
+            We appreciate your understanding as we try to manage our number of open issues.


### PR DESCRIPTION
As a way to help manage our number of open issues, we'll be closing issues that we've responded to and haven't heard back from after 14 days.

This won't happen unless we've evaluated and responded to the issue, so no issues will be automatically closed. 