### PR TITLE
Fix issue in workflow to convert code to JS

### DIFF
--- a/.github/workflows/convert-to-js.yml
+++ b/.github/workflows/convert-to-js.yml
@@ -44,13 +44,6 @@ jobs:
       - name: Remove Typescript files
         run: find app \( -name "*.ts" -o -name "*.tsx" \) -delete
 
-      - name: Remove tsc from the build command
-        run: |
-          patternToRemove="tsc && "
-          sedChangesFile=sedchanges.log
-          sed -i "s/^\( *\"build\": \".*\)$patternToRemove\(.*\)$/\1\2/w $sedChangesFile" package.json
-          if [ -s $sedChangesFile ]; then rm $sedChangesFile; else echo replacement failed; exit 1; fi
-
       - name: Run prettier
         run: yarn prettier -w "app/**/*.{js,jsx}" --plugin @shopify/prettier-config
 
@@ -69,13 +62,23 @@ jobs:
               { "blankLine": "always", "prev": "block-like", "next": "*" }
             ]}'
 
-      - name: Stage changes to files
+      - name: Prepare files for git
         run: |
           git config user.name GitHub
           git config user.email noreply@github.com
           git fetch
           git restore --staged package.json
           git restore package.json
+
+      - name: Remove tsc from the build command
+        run: |
+          patternToRemove="tsc && "
+          sedChangesFile=sedchanges.log
+          sed -i "s/^\( *\"build\": \".*\)$patternToRemove\(.*\)$/\1\2/w $sedChangesFile" package.json
+          if [ -s $sedChangesFile ]; then rm $sedChangesFile; else echo replacement failed; exit 1; fi
+
+      - name: Stage changes to files
+        run: |
           git add .
           git checkout -b temp_javascript_updates
           git commit -m "Convert template to Javascript"


### PR DESCRIPTION
This PR fixes an issue with the workflow to convert the code to Javascript, where we restored `package.json` after we edited the build command to work in it. This change makes us restore it _and then_ update the command.