### PR TITLE
Revert "Bump prettier from 2.8.8 to 3.1.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/react-dom": "^18.2.14",
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^8.8.0",
-    "prettier": "^3.1.1",
+    "prettier": "^2.8.8",
     "typescript": "^5.2.2"
   },
   "workspaces": {


### PR DESCRIPTION
Reverts Shopify/shopify-app-template-remix#452

CI on the PR was passing but then failed on main. Reverting for now.