### PR TITLE
[Fix] Convert TS to JS workflow

### DIFF
--- a/.github/workflows/convert-to-js.yml
+++ b/.github/workflows/convert-to-js.yml
@@ -24,7 +24,8 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn add -W --dev @shopify/prettier-config @shopify/eslint-plugin --ignore-engines
+        # run: yarn add -W --dev @shopify/prettier-config @shopify/eslint-plugin --ignore-engines
+        run: yarn add -W --dev @shopify/eslint-plugin --ignore-engines
 
       - name: Transpile to Javascript
         run: |
@@ -45,7 +46,8 @@ jobs:
         run: find app \( -name "*.ts" -o -name "*.tsx" \) -delete
 
       - name: Run prettier
-        run: yarn prettier -w "app/**/*.{js,jsx}" --plugin @shopify/prettier-config
+        # run: yarn prettier -w "app/**/*.{js,jsx}" --plugin @shopify/prettier-config
+        run: yarn prettier -w "app/**/*.{js,jsx}"
 
       - name: Run ESLint
         run: |


### PR DESCRIPTION
### WHY are these changes introduced?

The following command,

`yarn prettier -w "app/**/*.{js,jsx}" --plugin @shopify/prettier-config`

now produces the error,

`Error:  Module "file:///home/runner/work/shopify-app-template-remix/shopify-app-template-remix/node_modules/@shopify/prettier-config/index.json" needs an import assertion of type "json"`

This is preventing the JS template from being published.

### WHAT is this pull request doing?

Removing `@shopify/prettier-config` because it is incompatible with the latest update of `prettier` to v3. 

### Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
