### PR TITLE
Stop using prettier-plugin in CI JS conversion

### DIFF
--- a/.github/workflows/convert-to-js.yml
+++ b/.github/workflows/convert-to-js.yml
@@ -24,7 +24,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn add -W --dev @shopify/prettier-config @shopify/eslint-plugin --ignore-engines
+        run: yarn add -W --dev @shopify/eslint-plugin --ignore-engines
 
       - name: Transpile to Javascript
         run: |
@@ -47,7 +47,7 @@ jobs:
           find . -name ".graphqlrc.ts" -delete
 
       - name: Run prettier
-        run: yarn prettier -w "app/**/*.{js,jsx}" --config node_modules/@shopify/prettier-config/index.json
+        run: yarn prettier -w "app/**/*.{js,jsx}"
 
       - name: Run ESLint
         run: |


### PR DESCRIPTION
It turns out that we weren't applying the plugin before (or it was superseded by the eslint plugin, not sure). I believe just removing it will give us a similar end result.