### PR TITLE
[Versioned app config] Remove config push CLI command from scripts and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,24 +178,24 @@ Shopify apps are best when they are embedded into the Shopify Admin. This templa
 ### OAuth goes into a loop when I change my app's scopes
 
 If you change your app's scopes and authentication goes into a loop and fails with a message from Shopify that it tried too many times, you might have forgotten to update your scopes with Shopify.
-To do that, you can run the `config push` CLI command.
+To do that, you can run the `deploy` CLI command.
 
 Using yarn:
 
 ```shell
-yarn shopify app config push
+yarn deploy
 ```
 
 Using npm:
 
 ```shell
-npm run shopify app config push
+npm run deploy
 ```
 
 Using pnpm:
 
 ```shell
-pnpm run shopify app config push
+pnpm run deploy
 ```
 
 ### My webhook subscriptions aren't being updated

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "predev": "prisma generate && prisma migrate deploy",
     "dev": "shopify app dev",
     "config:link": "shopify app config link",
-    "config:push": "shopify app config push",
     "generate": "shopify app generate",
     "deploy": "shopify app deploy",
     "config:use": "shopify app config use",


### PR DESCRIPTION
### WHY are these changes introduced?

As part of versioned app config, the `shopify app config push` command is no longer supported. Users will need to use `app deploy` instead.

### WHAT is this pull request doing?

* Removes the `config push` command in the package.json scripts
* Edits the README to replace references of `config push` to `deploy`

### Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
