### PR TITLE
Make app-bridge-types regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@remix-run/react": "^2.0.0",
     "@remix-run/serve": "^2.0.0",
     "@shopify/app": "^3.50.0",
+    "@shopify/app-bridge-types": "^0.0.6",
     "@shopify/cli": "^3.50.0",
     "@shopify/polaris": "^12.0.0",
     "@shopify/shopify-api": "^9.2.0",
@@ -38,7 +39,6 @@
   "devDependencies": {
     "@remix-run/eslint-config": "^2.0.0",
     "@shopify/api-codegen-preset": "^0.0.2",
-    "@shopify/app-bridge-types": "^0.0.6",
     "@types/eslint": "^8.40.0",
     "@types/node": "^20.6.3",
     "@types/react": "^18.2.31",


### PR DESCRIPTION
### WHY are these changes introduced?

When deploying Shopify remix app to Render.com, the build was failing because it could not find this dependency (the Dockerfile does not install dev dependencies, and this one seems to be required in production despite being a dev dependency)

### WHAT is this pull request doing?

Moving the package from a dev dependency to a regular/prod dependency 

### Checklist

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
