### PR TITLE
Move predev script to web.toml dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "scripts": {
     "build": "tsc && remix build",
-    "predev": "prisma generate && prisma migrate deploy",
     "dev": "shopify app dev",
     "config:link": "shopify app config link",
     "generate": "shopify app generate",

--- a/shopify.web.toml
+++ b/shopify.web.toml
@@ -3,7 +3,7 @@ roles = ["frontend", "backend"]
 webhooks_path = "/webhooks"
 
 [commands]
-dev = "npm exec remix dev"
+dev = "npx prisma generate && npx prisma migrate deploy && npm exec remix dev"
 
 [hmr_server]
 http_paths = ["/ping"]


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
- We need to run prisma migration before `dev`
- The migration was added to the `predev` script because the CLI `web.toml` didn't have support for concatenated commands but that has changed on CLI 3.56 and the migration can be defined in the toml now.
- We shouldn't use `predev` because it only works when you run `npm run dev` and not `npm run shopify app dev` or if you use a global version of the CLI.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Move prisma migration from `predev` to the `dev` config in `web.toml`
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
