### PR TITLE
Move vite-tsconfig-paths to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "isbot": "^4.1.0",
     "prisma": "^5.8.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "vite-tsconfig-paths": "^4.3.1"
   },
   "devDependencies": {
     "@remix-run/eslint-config": "^2.7.1",
@@ -48,8 +49,7 @@
     "eslint-config-prettier": "^9.1.0",
     "prettier": "^3.2.4",
     "typescript": "^5.2.2",
-    "vite": "^5.1.3",
-    "vite-tsconfig-paths": "^4.3.1"
+    "vite": "^5.1.3"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #569 

The `vite-tsconfig-paths` dependency is used when building the app for production, so it can't be in `devDependencies`.

### WHAT is this pull request doing?

Moving it up to `dependencies` so building works in production mode.