### PR TITLE
Restrict served files in dev mode

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,6 +38,14 @@ export default defineConfig({
   server: {
     port: Number(process.env.PORT || 3000),
     hmr: hmrConfig,
+    fs: {
+      // See https://vitejs.dev/config/server-options.html#server-fs-allow for more information
+      allow: [
+        "app",
+        "node_modules/@shopify/polaris/build/esm/styles.css",
+        "node_modules/@remix-run/dev/dist/config/defaults/entry.client.tsx",
+      ],
+    },
   },
   plugins: [
     remix({


### PR DESCRIPTION
### WHY are these changes introduced?

In development mode, the Vite server will default to serving every file in the project folder, which we don't want since there are backend-only files in the repo.

### WHAT is this pull request doing?

Adding [`server.fs.allow`](https://vitejs.dev/config/server-options.html#server-fs-allow) rules for the files we do want to load, so that it more closely matches the production setup.
