### PR TITLE
Fix vite fs.allow config for pnpm

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,11 +40,7 @@ export default defineConfig({
     hmr: hmrConfig,
     fs: {
       // See https://vitejs.dev/config/server-options.html#server-fs-allow for more information
-      allow: [
-        "app",
-        "node_modules/@shopify/polaris/build/esm/styles.css",
-        "node_modules/@remix-run/dev/dist/config/defaults/entry.client.tsx",
-      ],
+      allow: ["app", "node_modules"],
     },
   },
   plugins: [


### PR DESCRIPTION
### WHY are these changes introduced?

In #580, we added some restrictions to which files were served in vite's development server so it more closely matches production. However, that broke for `pnpm` because we can't guarantee the paths of the files we need to load from `node_modules`.

### WHAT is this pull request doing?

Allowing imports for all of `node_modules` to make it easier to e.g. import other CSS bundles, and fix the `pnpm` issue.