### PR TITLE
Fix shopify.toast error

### DIFF
--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -82,7 +82,8 @@ export default function Index() {
     if (productId) {
       shopify.toast.show("Product created");
     }
-  }, [productId, shopify.toast]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [productId]);
   const generateProduct = () => submit({}, { replace: true, method: "POST" });
 
   return (


### PR DESCRIPTION
### WHY are these changes introduced?

After upgrading `app-bridge-react` we were getting an error that was caused by the `shopify.toast` being in the dependency array.

<img width="1232" alt="image" src="https://github.com/Shopify/shopify-app-template-remix/assets/23265671/61b784be-fc58-4e53-b8ac-333da3167456">


### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

You can test this template with the following command
```
npm init @shopify/app@latest -- --template=https://github.com/Shopify/shopify-app-template-remix.git#liz/fix-shopify-toast-error

```

### Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
