### PR TITLE
Bump @shopify/shopify-app-session-storage-prisma from 4.0.1 to 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@shopify/polaris": "^12.0.0",
     "@shopify/shopify-api": "^9.2.0",
     "@shopify/shopify-app-remix": "^2.5.0",
-    "@shopify/shopify-app-session-storage-prisma": "^4.0.1",
+    "@shopify/shopify-app-session-storage-prisma": "^4.0.2",
     "isbot": "^5.1.0",
     "prisma": "^5.8.0",
     "react": "^18.2.0",


### PR DESCRIPTION
Bump [@shopify/shopify-app-session-storage-prisma](https://github.com/Shopify/shopify-app-js) from 4.0.1 to 4.0.2