### PR TITLE
Bump @shopify/shopify-api from 9.2.0 to 9.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@shopify/app": "^3.50.0",
     "@shopify/cli": "^3.50.0",
     "@shopify/polaris": "^12.0.0",
-    "@shopify/shopify-api": "^9.2.0",
+    "@shopify/shopify-api": "^9.5.1",
     "@shopify/shopify-app-remix": "^2.5.0",
     "@shopify/shopify-app-session-storage-prisma": "^4.0.1",
     "isbot": "^5.1.0",


### PR DESCRIPTION
Bump [@shopify/shopify-api](https://github.com/Shopify/shopify-api-js) from 9.2.0 to 9.5.1