### PR TITLE
Bump prisma and @prisma/client from 5.8.0 to 5.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@prisma/client": "^5.8.0",
+    "@prisma/client": "^5.11.0",
     "@remix-run/dev": "^2.7.1",
     "@remix-run/node": "^2.7.1",
     "@remix-run/react": "^2.7.1",
@@ -32,7 +32,7 @@
     "@shopify/shopify-app-remix": "^2.5.0",
     "@shopify/shopify-app-session-storage-prisma": "^4.0.1",
     "isbot": "^5.1.0",
-    "prisma": "^5.8.0",
+    "prisma": "^5.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "vite-tsconfig-paths": "^4.3.1"


### PR DESCRIPTION
Bump [@prisma/client](https://github.com/prisma/prisma) from 5.8.0 to 5.11.0
Bump [prisma](https://github.com/prisma/prisma) from 5.8.0 to 5.11.0