### PR TITLE
Add warning about Prisma string lengths

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,6 +5,9 @@ generator client {
   provider = "prisma-client-js"
 }
 
+// Note that some adapters may set a maximum length for the String type by default, please ensure your strings are long
+// enough when changing adapters.
+// See https://www.prisma.io/docs/orm/reference/prisma-schema-reference#string for more information
 datasource db {
   provider = "sqlite"
   url      = "file:dev.sqlite"


### PR DESCRIPTION
### WHY are these changes introduced?

For some adapters (particularly MySQL), Prisma sets a limit on string lengths by default, which might be a problem if an app uses enough scopes that it reaches the default 191 character limit.

### WHAT is this pull request doing?

Adding a warning to the schema files to help make developers aware that they need to consider their string lengths depending on their adapters.