### PR TITLE
Improve CSS imports

### DIFF
--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -3,9 +3,11 @@ import { json } from "@remix-run/node";
 import { Link, Outlet, useLoaderData, useRouteError } from "@remix-run/react";
 import { boundary } from "@shopify/shopify-app-remix/server";
 import { AppProvider } from "@shopify/shopify-app-remix/react";
-import "@shopify/polaris/build/esm/styles.css";
+import polarisStyles from "@shopify/polaris/build/esm/styles.css?url";
 
 import { authenticate } from "../shopify.server";
+
+export const links = () => [{ rel: "stylesheet", href: polarisStyles }];
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   await authenticate.admin(request);

--- a/app/routes/auth.login/route.tsx
+++ b/app/routes/auth.login/route.tsx
@@ -12,11 +12,13 @@ import {
   TextField,
 } from "@shopify/polaris";
 import polarisTranslations from "@shopify/polaris/locales/en.json";
-import "@shopify/polaris/build/esm/styles.css";
+import polarisStyles from "@shopify/polaris/build/esm/styles.css?url";
 
 import { login } from "../../shopify.server";
 
 import { loginErrorMessage } from "./error.server";
+
+export const links = () => [{ rel: "stylesheet", href: polarisStyles }];
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const errors = loginErrorMessage(await login(request));


### PR DESCRIPTION
### WHY are these changes introduced?

In some cases, importing global frontend CSS files as modules can cause the CSS to be wiped out when a file is saved and triggers an HMR reload in the template.

### WHAT is this pull request doing?

Loading global CSS files whose classes we don't need to reference in the code with a `?url` flag so they're loaded from the URL, and don't break on HMR reloads.