### PR TITLE
Remove redundant ignores in .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,13 +1,7 @@
 package.json
-.cache
 .shadowenv.d
 .vscode
-build
 node_modules
 prisma
 public
-shopify-app-remix
-.github
-tmp
-*.yml
 .shopify


### PR DESCRIPTION
JetBrains IDE tells me that these removed items are already covered by 'node_modules'. They seem to be right. When you run prettier, none of the files gets run.