### PR TITLE
Specific config file to graphql-codegen

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "shopify": "shopify",
     "prisma": "prisma",
-    "graphql-codegen": "graphql-codegen --config=\".graphqlrc.ts\"",
+    "graphql-codegen": "graphql-codegen --config .graphqlrc.ts",
     "vite": "vite"
   },
   "type": "module",


### PR DESCRIPTION
Without specifying the config, the `graphql-codegen` command will fail. This PR solves that error by pointing the command to the correct config file.