### PR TITLE
Pin Undici to 6.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,11 @@
   },
   "trustedDependencies": [
     "@shopify/plugin-cloudflare"
-  ]
+  ],
+  "resolutions": {
+    "undici": "6.13.0"
+  },
+  "overrides": {
+    "undici": "6.13.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "prisma": "^5.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "undici": "6.13.0",
     "vite-tsconfig-paths": "^4.3.1"
   },
   "devDependencies": {
@@ -58,11 +59,5 @@
   },
   "trustedDependencies": [
     "@shopify/plugin-cloudflare"
-  ],
-  "resolutions": {
-    "undici": "6.13.0"
-  },
-  "overrides": {
-    "undici": "6.13.0"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "prisma": "^5.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "undici": "6.13.0",
     "vite-tsconfig-paths": "^4.3.1"
   },
   "devDependencies": {
@@ -59,5 +58,11 @@
   },
   "trustedDependencies": [
     "@shopify/plugin-cloudflare"
-  ]
+  ],
+  "resolutions": {
+    "undici": "6.13.0"
+  },
+  "overrides": {
+    "undici": "6.13.0"
+  }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The `@remix-run/node` dependency requires `undici ^6.10.1`, which recently [dropped support for Node <18.17](https://github.com/nodejs/undici/pull/3125) in v6.14.

But the CLI should work with Node > 18.12, so initializing a Remix app with that Node version is currently crashing:

```
Error coming from `npm install`

Command failed with exit code 1: npm install
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: undici@6.14.1
npm ERR! notsup Not compatible with your version of node/npm: undici@6.14.1
npm ERR! notsup Required: {"node":">=18.17"}
npm ERR! notsup Actual:   {"npm":"8.19.2","node":"v18.12.0"}
```

### WHAT is this pull request doing?

Adds a resolution/override to pin Undici to 6.13.0, which [works with Node 18.12](https://github.com/nodejs/undici/blob/v6.13.0/package.json#L128).

### Test this PR
```bash
nvm use 18.12
shopify app init --template https://github.com/Shopify/shopify-app-template-remix#pin-undici 
shopify app init --template https://github.com/Shopify/shopify-app-template-remix#pin-undici --package-manager yarn
shopify app init --template https://github.com/Shopify/shopify-app-template-remix#pin-undici --package-manager pnpm
shopify app init --template https://github.com/Shopify/shopify-app-template-remix#pin-undici --package-manager bun
```

### Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
