### PR TITLE
Exclude node 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "vite": "vite"
   },
   "type": "module",
+  "engines": {
+    "node": ">=16.0.0 <22.0.0"
+  },
   "dependencies": {
     "@prisma/client": "^5.11.0",
     "@remix-run/dev": "^2.7.1",


### PR DESCRIPTION
### WHY are these changes introduced?

* Node 22 removes import type assertions which are used in the shopify-app-remix library
* We are investigating the fix for this, but until then we do not want to allow user to use node 22

### Test this PR
```bash
npm init @shopify/app@latest -- --template=https://github.com/Shopify/shopify-app-template-remix.git#<your-branch-name>
```

<img width="535" alt="image" src="https://github.com/Shopify/shopify-app-template-remix/assets/23265671/dd282142-81d7-4580-b8e2-7b86c70e3b20">

<img width="1178" alt="image" src="https://github.com/Shopify/shopify-app-template-remix/assets/23265671/23df4343-f652-4990-ad35-521131740da4">

https://github.com/Shopify/shopify-app-template-remix/assets/23265671/cde9d3d3-305e-45e4-abcb-6ea4de08b3b7



### Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
