### PR TITLE
Delete lockfiles from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,3 @@ node_modules
 database.sqlite
 
 .env
-package-lock.json
-yarn.lock


### PR DESCRIPTION
### WHY are these changes introduced?

Dependency version mismatches between developers working on single app, and production builds can cause unpredictable behaviour. By removing lockfiles from `.gitignore` it's less likely developers will accidentally forget to commit them.

For context - I cloned a project earlier today that I couldn't get running because of issues with multiple React versions. This change doesn't solve that issue directly, but having noticed the lockfile wasn't committed, we added one that worked for someone else on the team and after reinstalling everything runs smoothly.

I've chosen not to include any lockfiles in this PR because I don't know if the template is purposely kept lockfile-less, so users can install the latest dependency versions on app creation. Also I assume we don't want to lock users to `npm`, `yarn` or `pnpm`.

### WHAT is this pull request doing?

Removes `yarn.lock` and `package-lock.json` from `.gitignore`

### Test this PR
```bash
npm init @shopify/app@latest -- --template=https://github.com/Shopify/shopify-app-template-remix.git#feature/stop-ignoring-lockfiles
```

### Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [x] I have made changes to the `README.md` file and other related documentation, if applicable

I haven't updated any tests here because I don't think it's necessary, let me know if you want anything testing though.