### PR TITLE
Increase maximum dependabot PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+    # Dependabot defaults to 5 open pull requests at a time
+    open-pull-requests-limit: 100


### PR DESCRIPTION
This PR increases the maximum number of open dependabot PRs to ensure we don't overlook dependencies.