### PR TITLE
Reduce docker image size:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ ENV NODE_ENV=production
 
 COPY package.json package-lock.json* ./
 
-RUN npm install --omit=dev && npm cache clean --force
+RUN npm ci --omit=dev && npm cache clean --force
 # Remove CLI packages since we don't need them in production by default.
 # Remove this line if you want to run CLI commands in your container.
-RUN npm remove @shopify/app @shopify/cli
+RUN npm remove @shopify/cli
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,18 @@ FROM node:18-alpine
 EXPOSE 3000
 
 WORKDIR /app
-COPY . .
 
 ENV NODE_ENV=production
 
-RUN npm install --omit=dev
+COPY package.json package-lock.json* ./
+
+RUN npm install --omit=dev && npm cache clean --force
 # Remove CLI packages since we don't need them in production by default.
 # Remove this line if you want to run CLI commands in your container.
 RUN npm remove @shopify/app @shopify/cli
+
+COPY . .
+
 RUN npm run build
 
 # You'll probably want to remove this in production, it's here to make it easier to test things!


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #720 . Relates to previous attempts to reduce the file size on #418

* The docker image size for this app is ~ 1.8 GB
* I appears that most of this image size is unnecessary - the actually-used disk space on a running container is much smaller (~500 MB)
* After doing some digging, the main reason for this size is the node modules cache
* It seems like this gets included in the image unless `npm cache clean` gets run
* Additionally, if that line is not run in the same `RUN` as the `npm install`, then it will still show up in the docker image layer cache

### WHAT is this pull request doing?

* This PR proposes adding an `npm cache clean --force` to the `npm install` line
* The proposed strategy reduces image sizes down to ~ 500 MB.
* An additional part of this proposal is to only copy the package.json & lock files before the npm install, which improves docker image layer caching between builds where no dependencies have been changed. This can be removed if preferred.

### Checklist

- [x] I ran this locally to check the docker build still works, plus double-check its image size

```
$ docker image ls
REPOSITORY                   TAG          IMAGE ID       CREATED          SIZE
shopify-app-template-remix   after-fix    b1a72b194a84   8 seconds ago    522MB
shopify-app-template-remix   before-fix   d1e581de7c98   8 minutes ago    1.81GB
```
