### PR TITLE
Use CLI predev command

### DIFF
--- a/shopify.web.toml
+++ b/shopify.web.toml
@@ -3,4 +3,5 @@ roles = ["frontend", "backend"]
 webhooks_path = "/webhooks"
 
 [commands]
-dev = "npx prisma generate && npx prisma migrate deploy && npm exec remix vite:dev"
+predev = "npx prisma generate"
+dev = "npx prisma migrate deploy && npm exec remix vite:dev"


### PR DESCRIPTION
### WHY are these changes introduced?

The `prisma generate` command currently outputs a lot of information, which bloats the (already substantial) logs when an app starts. There is currently no way of turning down the amount of information it outputs, so we need to hide the output for now.

### WHAT is this pull request doing?

Using the `predev` command which will silently run a setup command before actually starting the server.

Before:
![image](https://github.com/Shopify/shopify-app-template-remix/assets/64600052/34ecdf80-0180-4b8e-81c4-1c95ba2e1e2c)

After:
![image](https://github.com/Shopify/shopify-app-template-remix/assets/64600052/1b93ecb3-8084-404b-ac5b-09d9e2abe0a8)

### Test this PR
```bash
npm init @shopify/app@latest -- --template=https://github.com/Shopify/shopify-app-template-remix.git#use_predev_command
```