### PR TITLE
Allow using Node 21

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "type": "module",
   "engines": {
-    "node": "^18.20 || ^20.10 || ^22"
+    "node": "^18.20 || ^20.10 || >=21.0.0"
   },
   "dependencies": {
     "@prisma/client": "^5.11.0",


### PR DESCRIPTION
### WHY are these changes introduced?

We recently updated the supported node versions because we needed specific versions of 18 and 20, but we accidentally ignored node 21 which should still work.

### WHAT is this pull request doing?

Making the engine version requirements a little more flexible so we don't have to worry about future versions.

### Test this PR

```bash
npm init @shopify/app@latest -- --template=https://github.com/Shopify/shopify-app-template-remix.git#add_node_21_support
```
