### PR TITLE
Ignore built assets for UI extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ database.sqlite
 .env
 package-lock.json
 yarn.lock
+
+/extensions/*/dist


### PR DESCRIPTION
### WHY are these changes introduced?

This ignores `extensions/**/dist` because those contain built assets which change every time extensions are bundled. Developers shouldn't need to include these bundled assets in version control, so they should be ignored.

### Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
