### PR TITLE
Add changelog to track changes in repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,13 +22,13 @@ Fixes #0000 <!-- link to issue if one exists -->
 -->
 
 ### Test this PR
+
 ```bash
 shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#<your-branch-name>
 ```
 
 ### Checklist
 
-**Note**: once this PR is merged, it becomes a new release for this template.
-
-- [ ] I have added/updated tests for this change
 - [ ] I have made changes to the `README.md` file and other related documentation, if applicable
+- [ ] I have added an entry to `CHANGELOG.md`
+- [ ] I'm aware I need to create a new release when this PR is merged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @shopify/shopify-app-template-remix
+
+## v2024.07.16
+
+Started tracking changes and releases using calver


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #771

It is currently difficult for devs to know when we've made changes to this template because:

- they need to manually check if something changed in the repo
- the actual changes aren't easy to find

### WHAT is this pull request doing?

Starting a changelog, which will be calver-based - so we won't track which changes are breaking or not as the only way apps can follow the template is by manually copying the changes.

Since this template is not supposed to be updated often, we shouldn't have to create too many releases for it.

### Checklist

- [x] I have made changes to the `README.md` file and other related documentation, if applicable
- [x] I have added an entry to `CHANGELOG.md`
- [x] I'm aware I need to create a new release when this PR is merged