### PR TITLE
Ignore all .env in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ node_modules
 database.sqlite
 
 .env
+.env.*
+
 package-lock.json
 yarn.lock
 


### PR DESCRIPTION
* If multiple API keys/environments  are used for an app repo the CLI will create .env files with the API keys for each
* The format would be `.env.app-name`

### WHY are these changes introduced?

Fixes #778 

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#<your-branch-name>
```

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged
