### PR TITLE
Add check for shop_redact webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # @shopify/shopify-app-template-remix
 
+## v2024.08.06
+Allow `SHOP_REDACT` webhook to process without admin context
+
 ## v2024.07.16
 
 Started tracking changes and releases using calver

--- a/app/routes/webhooks.tsx
+++ b/app/routes/webhooks.tsx
@@ -5,8 +5,10 @@ import db from "../db.server";
 export const action = async ({ request }: ActionFunctionArgs) => {
   const { topic, shop, session, admin } = await authenticate.webhook(request);
 
-  if (!admin) {
+  if (!admin && topic !== 'SHOP_REDACT') {
     // The admin context isn't returned if the webhook fired after a shop was uninstalled.
+    // The SHOP_REDACT webhook will be fired up to 48 hours after a shop uninstalls the app.
+    // Because of this, no admin context is available.
     throw new Response();
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #808 
* An app will receive a `SHOP_REDACT` webhook up to [48 hours after a shop has uninstalled](https://shopify.dev/docs/apps/build/privacy-law-compliance#shop-redact) an app.
* Because the app will be uninstalled an admin context will not be returned, but the webhook will still need to be actioned.


### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#<your-branch-name>
```

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [x] I have added an entry to `CHANGELOG.md`
- [x] I'm aware I need to create a new release when this PR is merged
