### PR TITLE
Add pnpm lock file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ database.sqlite
 
 package-lock.json
 yarn.lock
+pnpm-lock.yaml
 
 /extensions/*/dist


### PR DESCRIPTION
### WHY are these changes introduced?

We're currently not ignoring pnpm lock files. This is removed by the CLI but might still be accidentally committed by developers using pnpm in this repo.

### WHAT is this pull request doing?

Adding the file to `.gitignore`.
