### PR TITLE
Search GraphQL type definitions in the .server folder

### DIFF
--- a/.graphqlrc.ts
+++ b/.graphqlrc.ts
@@ -9,7 +9,7 @@ function getConfig() {
       default: shopifyApiProject({
         apiType: ApiType.Admin,
         apiVersion: LATEST_API_VERSION,
-        documents: ["./app/**/*.{js,ts,jsx,tsx}"],
+        documents: ["./app/**/*.{js,ts,jsx,tsx}", "./app/.server/**/*.{js,ts,jsx,tsx}"],
         outputDir: "./app/types",
       }),
     },


### PR DESCRIPTION
### WHY are these changes introduced?

Remix supports marking all files as server-only using the [.server](https://remix.run/docs/en/main/file-conventions/-server) directory.
However, the folder starting with a dot will be regarded as hidden and excluded by the current glob pattern when running the `graphql-codegen` command. This will make the generated files incorrect when someone writes GraphQL in the `.server`. It's not easy to notice since the current pattern looks to match the files in the `.server`. Moreover, if we put all GraphQL type definitions in the `.server` folder, it even fails the `graphql-codegen` command.
So I open this PR to include the `.server` files by default.

### WHAT is this pull request doing?

#### Changeset
- Add the `.server` folder to the `documents` of `.graphqlrc.ts` manually for searching GraphQL type definitions 

#### Screenshots
Before,  the `graphql-codegen` command failed since all GraphQL definitions are in the `.server`  folder:
<img width="742" alt="image" src="https://github.com/user-attachments/assets/2bf689e4-8897-4327-8e56-14993996915d">
After, work as expected:
<img width="704" alt="image" src="https://github.com/user-attachments/assets/96fd8093-72c3-4d7d-b7f3-310a675fb8d1">


### Test this PR

Only add a match pattern and do not affect the main functions,  and tested in my other projects, no more tests are needed IMO.