### PR TITLE
[Chore] Remove db removal call from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,4 @@ COPY . .
 
 RUN npm run build
 
-# You'll probably want to remove this in production, it's here to make it easier to test things!
-RUN rm -f prisma/dev.sqlite
-
 CMD ["npm", "run", "docker-start"]


### PR DESCRIPTION
We're currently removing the local database file from the Dockerfile set up. This is there mostly to prevent accidentally copying the dev DB over prod, but:

- Apps should ideally not be using SQLite in production, or setting a different path
- We don't want to remove production data on deploys if they do want to keep it that way

This line doesn't really add any value and may lead to unexpected behaviour, so we should just remove it.