### PR TITLE
[Chore] Stop using deprecated mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # @shopify/shopify-app-template-remix
 
+## 2024.08.19
+
+Replaced deprecated `productVariantUpdate` with `productVariantsBulkUpdate`
+
 ## v2024.08.06
+
 Allow `SHOP_REDACT` webhook to process without admin context
 
 ## v2024.07.16

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -60,26 +60,25 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   );
   const responseJson = await response.json();
 
-  const variantId =
-    responseJson.data!.productCreate!.product!.variants.edges[0]!.node!.id!;
+  const product = responseJson.data!.productCreate!.product!;
+  const variantId = product.variants.edges[0]!.node!.id!;
+
   const variantResponse = await admin.graphql(
     `#graphql
-      mutation shopifyRemixTemplateUpdateVariant($input: ProductVariantInput!) {
-        productVariantUpdate(input: $input) {
-          productVariant {
-            id
-            price
-            barcode
-            createdAt
-          }
+    mutation shopifyRemixTemplateUpdateVariant($productId: ID!, $variants: [ProductVariantsBulkInput!]!) {
+      productVariantsBulkUpdate(productId: $productId, variants: $variants) {
+        productVariants {
+          id
+          price
+          barcode
+          createdAt
         }
-      }`,
+      }
+    }`,
     {
       variables: {
-        input: {
-          id: variantId,
-          price: Math.random() * 100,
-        },
+        productId: product.id,
+        variants: [{ id: variantId, price: "100.00" }],
       },
     },
   );
@@ -88,7 +87,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   return json({
     product: responseJson!.data!.productCreate!.product,
-    variant: variantResponseJson!.data!.productVariantUpdate!.productVariant,
+    variant:
+      variantResponseJson!.data!.productVariantsBulkUpdate!.productVariants,
   });
 };
 
@@ -205,7 +205,7 @@ export default function Index() {
                     </Box>
                     <Text as="h3" variant="headingMd">
                       {" "}
-                      productVariantUpdate mutation
+                      productVariantsBulkUpdate mutation
                     </Text>
                     <Box
                       padding="400"


### PR DESCRIPTION
### WHY are these changes introduced?

We're currently getting a warning in the template because we're using a deprecated GraphQL mutation.

### WHAT is this pull request doing?

Using the recommended alternative.

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#remove_deprecated_mutation
```

Run the app and see if it can still create a product.

### Checklist

- [x] I have added an entry to `CHANGELOG.md`
- [x] I'm aware I need to create a new release when this PR is merged
