### PR TITLE
Force graphql-config resolution to 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,9 +61,11 @@
     "@shopify/plugin-cloudflare"
   ],
   "resolutions": {
-    "undici": "6.13.0"
+    "undici": "6.13.0",
+    "graphql-config": "5.1.0"
   },
   "overrides": {
-    "undici": "6.13.0"
+    "undici": "6.13.0",
+    "graphql-config": "5.1.0"
   }
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
`graphql-config` released patch version 5.1.1 which included upgrading their minimatch dependency to version 10.
Minimatch 10 works only with node > 20.

Since most dependencies allow automatic patch updates, this broke the template for node 18


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#<your-branch-name>
```

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged
