### PR TITLE
Update api-codegen-preset package

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@remix-run/eslint-config": "^2.7.1",
-    "@shopify/api-codegen-preset": "^1.0.1",
+    "@shopify/api-codegen-preset": "^1.1.1",
     "@types/eslint": "^8.40.0",
     "@types/node": "^22.2.0",
     "@types/react": "^18.2.31",


### PR DESCRIPTION
This PR updates the dependency on api-codegen-preset so we can fix the JS conversion workflow, which was failing due to mismatched types from that package.