### PR TITLE
Unpin graphql-config dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,10 +60,6 @@
   "trustedDependencies": [
     "@shopify/plugin-cloudflare"
   ],
-  "resolutions": {
-    "undici": "6.13.0"
-  },
-  "overrides": {
-    "undici": "6.13.0"
-  }
+  "resolutions": {},
+  "overrides": {}
 }


### PR DESCRIPTION
As of v5.1.2, `graphql-config` no longer uses `minimatch` @ v10, which dropped support for node 18-. We can now unpin the dependency so we can continue to update it.