### PR TITLE
[Fix] Remove tilde imports

### DIFF
--- a/app/routes/webhooks.app.uninstalled.tsx
+++ b/app/routes/webhooks.app.uninstalled.tsx
@@ -1,6 +1,6 @@
 import type { ActionFunctionArgs } from "@remix-run/node";
-import { authenticate } from "~/shopify.server";
-import db from "~/db.server";
+import { authenticate } from "../shopify.server";
+import db from "../db.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   const { shop, session } = await authenticate.webhook(request);

--- a/app/routes/webhooks.customers.data_request.tsx
+++ b/app/routes/webhooks.customers.data_request.tsx
@@ -1,5 +1,5 @@
 import type { ActionFunctionArgs } from "@remix-run/node";
-import { authenticate } from "~/shopify.server";
+import { authenticate } from "../shopify.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   const { shop, payload } = await authenticate.webhook(request);

--- a/app/routes/webhooks.customers.redact.tsx
+++ b/app/routes/webhooks.customers.redact.tsx
@@ -1,5 +1,5 @@
 import type { ActionFunctionArgs } from "@remix-run/node";
-import { authenticate } from "~/shopify.server";
+import { authenticate } from "../shopify.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   const { shop, payload} = await authenticate.webhook(request);

--- a/app/routes/webhooks.shop.redact.tsx
+++ b/app/routes/webhooks.shop.redact.tsx
@@ -1,5 +1,5 @@
 import type { ActionFunctionArgs } from "@remix-run/node";
-import { authenticate } from "~/shopify.server";
+import { authenticate } from "../shopify.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   const { session } = await authenticate.webhook(request);


### PR DESCRIPTION
### WHY are these changes introduced?

* While we have the typescript version of the template configured to use `~/import/thing` we don't have it configured for the javascript version of the project.
* We can look into configuring it for javascript


### WHAT is this pull request doing?

* Change all the recently added tilde imports to absolute imports

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#remove-module-imports
```

