### PR TITLE
Fix race-y bug in db.server.ts

### DIFF
--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -4,12 +4,12 @@ declare global {
   var prisma: PrismaClient;
 }
 
-const prisma: PrismaClient = global.prisma || new PrismaClient();
-
 if (process.env.NODE_ENV !== "production") {
   if (!global.prisma) {
     global.prisma = new PrismaClient();
   }
 }
+
+const prisma: PrismaClient = global.prisma || new PrismaClient();
 
 export default prisma;


### PR DESCRIPTION
In the old code, two database connections get created in dev mode, which I think is not intentional.

Specifically:
1. On first load, the local `prisma` variable gets initialized to a new connection (as `global.prisma` is unset).
2. Since we are in dev mode, and `global.primsa` is not set, `global.prisma` gets initialized to yet another, fresh connection.
3. The first of these two connections gets exported and used.
4. For later HMR reloads, the 2nd connection is taken from `global.prisma`, means we have to DB connections being used in parallel.

This PR moves the global check to _after_ the dev mode check.