### PR TITLE
await deleting the sessions on uninstall webhook

### DIFF
--- a/app/routes/webhooks.app.uninstalled.tsx
+++ b/app/routes/webhooks.app.uninstalled.tsx
@@ -10,7 +10,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   // Webhook requests can trigger multiple times and after an app has already been uninstalled.
   // If this webhook already ran, the session may have been deleted previously.
   if (session) {
-    db.session.deleteMany({ where: { shop } });
+    await db.session.deleteMany({ where: { shop } });
   }
 
   return new Response();


### PR DESCRIPTION
### WHY are these changes introduced?

The afterAuth hook runs once on install. If a developer uninstalls and reinstalls, the afterAuth hook does not run because there is still a valid session. We need to properly await the deleting of sessions.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#iphipps\/invalidate-session-on-uninstall
```
1. add a console log to an afterAuth hook in `app/shopify.server.ts` to see when it runs.  
2. notice how the afterAuth hook runs every time you install and uninstall the app on your store

Compare the behavior to `main` notice how afterAuth is run once. 

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged
