### PR TITLE
WIP Update scopes config in toml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @shopify/shopify-app-template-remix
 
+## 2024.10.16
+
+- [868](https://github.com/Shopify/shopify-app-template-remix/pull/868) Update `access_scope` configuration in the `shopify.app.toml` file.
+
 ## 2024.10.02
 
 - [863](https://github.com/Shopify/shopify-app-template-remix/pull/863) Update to Shopify App API v2024-10 and shopify-app-remix v3.3.2

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -1,5 +1,7 @@
 # This file stores configurations for your Shopify app.
 
+[access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
 scopes = "write_products"
 
 [webhooks]


### PR DESCRIPTION
### WHY are these changes introduced?
* Scopes should be nested under the `access_scopes` [key](https://shopify.dev/docs/apps/build/cli-for-apps/app-configuration#access_scopes)
* Newer versions of the CLI will update the `shopify.app.toml` file to correctly nest the `scopes` field. But older versions of the CLI do not have this functionality, causing the required scopes to not be requested during install.

### WHAT is this pull request doing?

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#liz/update-scopes-shopify-app-toml
```

### Checklist
- [x] I have added an entry to `CHANGELOG.md`
- [x] I'm aware I need to create a new release when this PR is merged