### PR TITLE
Add Scopes Update Webhook to Remix Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@
 
 ## 2024.12.04
 
+- [875](https://github.com/Shopify/shopify-app-template-remix/pull/875) Add Scopes Update Webhook
+
+## 2024.12.04
+
 - [#891](https://github.com/Shopify/shopify-app-template-remix/pull/891) Enable remix future flags.
 
 ## 2024.11.26
-
 - [888](https://github.com/Shopify/shopify-app-template-remix/pull/888) Update restResources version to 2024-10
 
 ## 2024.11.06
@@ -33,7 +36,7 @@
 
 ## 2024.09.17
 
-- [842](https://github.com/Shopify/shopify-app-template-remix/pull/842)Move webhook processing to individual routes
+- [842](https://github.com/Shopify/shopify-app-template-remix/pull/842) Move webhook processing to individual routes
 
 ## 2024.08.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # @shopify/shopify-app-template-remix
 
+## 2024.12.18
+
+- [875](https://github.com/Shopify/shopify-app-template-remix/pull/875) Add Scopes Update Webhook
+
 ## 2024.12.05
 
 - [#910](https://github.com/Shopify/shopify-app-template-remix/pull/910) Install `openssl` in Docker image to fix Prisma (see [#25817](https://github.com/prisma/prisma/issues/25817#issuecomment-2538544254))
 - [#907](https://github.com/Shopify/shopify-app-template-remix/pull/907) Move `@remix-run/fs-routes` to `dependencies` to fix Docker image build
 - [#899](https://github.com/Shopify/shopify-app-template-remix/pull/899) Disable v3_singleFetch flag
 - [#898](https://github.com/Shopify/shopify-app-template-remix/pull/898) Enable the `removeRest` future flag so new apps aren't tempted to use the REST Admin API.
-
-## 2024.12.04
-
-- [875](https://github.com/Shopify/shopify-app-template-remix/pull/875) Add Scopes Update Webhook
 
 ## 2024.12.04
 

--- a/app/routes/webhooks.app.scopes_update.tsx
+++ b/app/routes/webhooks.app.scopes_update.tsx
@@ -1,0 +1,21 @@
+import type { ActionFunctionArgs } from "@remix-run/node";
+import { authenticate } from "../shopify.server";
+import db from "../db.server";
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+    const { payload, session, topic, shop } = await authenticate.webhook(request);
+    console.log(`Received ${topic} webhook for ${shop}`);
+
+    const current = payload.current as string[];
+    if (session) {
+        await db.session.update({   
+            where: {
+                id: session.id
+            },
+            data: {
+                scope: current.toString(),
+            },
+        });
+    }
+    return new Response();
+};

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -10,6 +10,11 @@ api_version = "2024-10"
   uri = "/webhooks/app/uninstalled"
   topics = ["app/uninstalled"]
 
+  # Handled by: /app/routes/webhooks.app.scopes_update.tsx
+  [[webhooks.subscriptions]]
+  topics = [ "app/scopes_update" ]
+  uri = "/webhooks/app/scopes_update"
+
   # Webhooks can have filters
   # Only receive webhooks for product updates with a product price >= 10.00
   # See: https://shopify.dev/docs/apps/build/webhooks/customize/filters


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Implements [Shopify Remix template - Subscribe to the webhook event(s) sent when scopes are updated ](https://github.com/Shopify/develop-app-runtime-primitives/issues/340)

<!--
  Context about the problem that’s being addressed.
-->

This adds the scopes-update webhook to the remix template, to allow the app to be notified and update its local database accordingly when a change in access scopes is made.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

https://github.com/user-attachments/assets/6237fb5c-daf1-4fa7-8310-cdd5318ed349


### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#add-scopes-update-webhook
```
Follow the instructions here to setup a optional scopes application with scopes revoke capabilities after scaffolding.
https://docs.google.com/spreadsheets/d/152j0NUJ-LjGKhgbQ73x_vPvcLJMRlcv7Dsip40dO5yE/edit?gid=1453682373#gid=1453682373

Alter the scopes as you see fit and check that the dev.sqlite file is being adjusted accordingly


### Checklist

- [x] I have made changes to the `README.md` file and other related documentation, if applicable
- [x] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged
