### PR TITLE
[fix] update productCreate mutation to use `product` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @shopify/shopify-app-template-remix
 
+## 2024.11.07
+
+- [882](https://github.com/Shopify/shopify-app-template-remix/pull/882) Update `productCreate` mutation to use `product` argument
+
 ## 2024.10.29
 
 - [876](https://github.com/Shopify/shopify-app-template-remix/pull/876) Update shopify-app-remix to v3.4.0 and shopify-app-session-storage-prisma to v5.1.5

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -30,8 +30,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   ];
   const response = await admin.graphql(
     `#graphql
-      mutation populateProduct($input: ProductInput!) {
-        productCreate(input: $input) {
+      mutation populateProduct($product: ProductCreateInput!) {
+        productCreate(product: $product) {
           product {
             id
             title
@@ -52,7 +52,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       }`,
     {
       variables: {
-        input: {
+        product: {
           title: `${color} Snowboard`,
         },
       },


### PR DESCRIPTION
### WHY are these changes introduced?

The `input` argument in `productCreate` has been [deprecated](https://shopify.dev/changelog/productinput-split-into-productcreateinput-and-productupdateinput-in-2024-10) in favor of `product` with a new `ProductCreateInput` type.

Related to https://github.com/Shopify/first-party-library-planning/issues/687

### WHAT is this pull request doing?

This updates the `productCreate` example to drop the deprecated use of `input`

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#<your-branch-name>
```

### Checklist

- [x] I have made changes to the `README.md` file and other related documentation, if applicable
- [x] I have added an entry to `CHANGELOG.md`
- [x] I'm aware I need to create a new release when this PR is merged
