### PR TITLE
Enable remove rest future flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,6 @@ The Remix app template comes with the following out-of-the-box functionality:
 
 - [OAuth](https://github.com/Shopify/shopify-app-js/tree/main/packages/shopify-app-remix#authenticating-admin-requests): Installing the app and granting permissions
 - [GraphQL Admin API](https://github.com/Shopify/shopify-app-js/tree/main/packages/shopify-app-remix#using-the-shopify-admin-graphql-api): Querying or mutating Shopify admin data
-- [REST Admin API](https://github.com/Shopify/shopify-app-js/tree/main/packages/shopify-app-remix#using-the-shopify-admin-rest-api): Resource classes to interact with the API
 - [Webhooks](https://github.com/Shopify/shopify-app-js/tree/main/packages/shopify-app-remix#authenticating-webhook-requests): Callbacks sent by Shopify when certain events occur
 - [AppBridge](https://shopify.dev/docs/api/app-bridge): This template uses the next generation of the Shopify App Bridge library which works in unison with previous versions.
 - [Polaris](https://polaris.shopify.com/): Design system that enables apps to create Shopify-like experiences

--- a/app/shopify.server.ts
+++ b/app/shopify.server.ts
@@ -5,7 +5,6 @@ import {
   shopifyApp,
 } from "@shopify/shopify-app-remix/server";
 import { PrismaSessionStorage } from "@shopify/shopify-app-session-storage-prisma";
-import { restResources } from "@shopify/shopify-api/rest/admin/2024-10";
 import prisma from "./db.server";
 
 const shopify = shopifyApp({
@@ -17,9 +16,9 @@ const shopify = shopifyApp({
   authPathPrefix: "/auth",
   sessionStorage: new PrismaSessionStorage(prisma),
   distribution: AppDistribution.AppStore,
-  restResources,
   future: {
     unstable_newEmbeddedAuthStrategy: true,
+    removeRest: true,
   },
   ...(process.env.SHOP_CUSTOM_DOMAIN
     ? { customShopDomains: [process.env.SHOP_CUSTOM_DOMAIN] }


### PR DESCRIPTION
### WHY are these changes introduced?

Shopify is [all-in on graphql](https://www.shopify.com/ca/partners/blog/all-in-on-graphql). We added this future flag to the shopify-app-remix package so developers can progressively remove REST.  Now we want to make sure that new apps don't use REST only to have to migrate to GraphQL

### WHAT is this pull request doing?

1. Enable the future flag
2. Remove a reference to REST in the README.md

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#enable-remove-rest-future-flag
```

### Checklist

- [x] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged
