### PR TITLE
Set `@remix-run/fs-routes` as a dependency to fix Dockerfile build

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@prisma/client": "^5.11.0",
     "@remix-run/dev": "^2.7.1",
+    "@remix-run/fs-routes": "^2.15.0",
     "@remix-run/node": "^2.7.1",
     "@remix-run/react": "^2.7.1",
     "@remix-run/serve": "^2.7.1",
@@ -41,7 +42,6 @@
   },
   "devDependencies": {
     "@remix-run/eslint-config": "^2.7.1",
-    "@remix-run/fs-routes": "^2.15.0",
     "@remix-run/route-config": "^2.15.0",
     "@shopify/api-codegen-preset": "^1.1.1",
     "@types/eslint": "^8.40.0",


### PR DESCRIPTION

### WHY are these changes introduced?

Fixes #906

Docker image build is breaking due to missing the `@remix-run/fs-routes` package on build.

### WHAT is this pull request doing?

Include `@remix-run/fs-routes` as a dependency in the `package.json` file to fix the Dockerfile build

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#fix-docker-build
```

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged
