### PR TITLE
Install OpenSSL in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2024.12.05
 
+- [#910](https://github.com/Shopify/shopify-app-template-remix/pull/910) Install `openssl` in Docker image to fix Prisma (see [#25817](https://github.com/prisma/prisma/issues/25817#issuecomment-2538544254))
 - [#907](https://github.com/Shopify/shopify-app-template-remix/pull/907) Move `@remix-run/fs-routes` to `dependencies` to fix Docker image build
 - [#899](https://github.com/Shopify/shopify-app-template-remix/pull/899) Disable v3_singleFetch flag
 - [#898](https://github.com/Shopify/shopify-app-template-remix/pull/898) Enable the `removeRest` future flag so new apps aren't tempted to use the REST Admin API.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:18-alpine
+RUN apk add --no-cache openssl
 
 EXPOSE 3000
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #909 

From https://github.com/prisma/prisma/issues/25817#issuecomment-2538544254

> Hey folks, Alberto from Prisma here. This issue arised due to a change in Alpine's Docker images, specifically in how and where OpenSSL libraries are stored (and, consequently, detected by Prisma Engines).
>
> Thanks to #25824, this issue is now solved. This fix will be shipped in Prisma 6.1.0 on December 17th, and is already available in Prisma 6.1.0-dev.14.

### WHAT is this pull request doing?

Install `openssl` in Docker container.

This can be removed after upgrading to Prisma 6.1.0

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#install-openssl
```

### Checklist

- [x] I have made changes to the `README.md` file and other related documentation, if applicable
- [x] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged
