### PR TITLE
Revert "Bump @types/react-dom from 18.3.5 to 19.0.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/eslint": "^9.6.1",
     "@types/node": "^22.2.0",
     "@types/react": "^18.2.31",
-    "@types/react-dom": "^19.0.1",
+    "@types/react-dom": "^18.2.14",
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^10.0.1",
     "prettier": "^3.2.4",


### PR DESCRIPTION
Reverts Shopify/shopify-app-template-remix#930

This upgrade caused this error when running: `shopify app init --template remix --flavor typescript`

```
Command failed with exit code 1: npm install
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: jan23-1048@undefined
npm error Found: @types/react@18.3.18
npm error node_modules/@types/react
npm error   dev @types/react@"^18.2.31" from the root project
npm error
npm error Could not resolve dependency:
npm error peer @types/react@"^19.0.0" from @types/react-dom@19.0.3
npm error node_modules/@types/react-dom
npm error   dev @types/react-dom@"^19.0.1" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /Users/arkham/.npm/_logs/2025-01-23T10_48_38_871Z-eresolve-report.txt
npm error A complete log of this run can be found in: /Users/arkham/.npm/_logs/2025-01-23T10_48_38_871Z-debug-0.log
```