### PR TITLE
Lock @graphql-tools/url-loader dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,10 @@
   "trustedDependencies": [
     "@shopify/plugin-cloudflare"
   ],
-  "resolutions": {},
-  "overrides": {}
+  "resolutions": {
+    "@graphql-tools/url-loader": "8.0.16"
+  },
+  "overrides": {
+    "@graphql-tools/url-loader": "8.0.16"
+  }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

* They dropped node 18 support in a patch change

### WHAT is this pull request doing?

```
npm list graphql-ws                                                                                                                                                                                           ─╯
app@ /Users/lizkenyib/workspace/shopify-app-template-remix
└─┬ @shopify/api-codegen-preset@1.1.2
  └─┬ @graphql-codegen/cli@5.0.3
    └─┬ @graphql-tools/url-loader@8.0.16
      └─┬ @graphql-tools/executor-graphql-ws@1.3.2
        └── graphql-ws@5.16.0
```

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#liz/lock-graphql-url-loader-dependency
```

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged
