### PR TITLE
Fix Prisma import issue in production

### DIFF
--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -1,15 +1,15 @@
 import { PrismaClient } from "@prisma/client";
 
 declare global {
-  var prisma: PrismaClient;
+  var prismaGlobal: PrismaClient;
 }
 
 if (process.env.NODE_ENV !== "production") {
-  if (!global.prisma) {
-    global.prisma = new PrismaClient();
+  if (!global.prismaGlobal) {
+    global.prismaGlobal = new PrismaClient();
   }
 }
 
-const prisma: PrismaClient = global.prisma || new PrismaClient();
+const prisma = global.prismaGlobal ?? new PrismaClient();
 
 export default prisma;


### PR DESCRIPTION
### WHY are these changes introduced?

The Prisma client in `db.server.ts` file is currently attached to the global object as `prisma`, allowing it to be used in a file without an explicit import. This works in development environment, but causes the app to crash in production due to the missing import. This fix ensures that using prisma without importing it will fail locally as well, prompting developers to import it properly and preventing production errors.

### WHAT is this pull request doing?

This pull request renames the Prisma client object from `prisma` to `prismaGlobal` in the `db.server.ts` file.