### PR TITLE
Correct minor misspelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Embedded Shopify apps must maintain the user session, which can be tricky inside
 2. Use the `redirect` helper returned from `authenticate.admin`. Do not use `redirect` from `@remix-run/node`
 3. Use `useSubmit` or `<Form/>` from `@remix-run/react`. Do not use a lowercase `<form/>`.
 
-This only applies if you app is embedded, which it will be by default.
+This only applies if your app is embedded, which it will be by default.
 
 ### Non Embedded
 


### PR DESCRIPTION
Correcting a minor typo. It should be "your" instead of "you".

Current version: "This only applies if you app is embedded" (INCORRECT)
Proposed update: "This only applies if your app is embedded" (CORRECT)

### WHY are these changes introduced?

Fixes a misspelling, for cosmetic purposes only.

### WHAT is this pull request doing?

Adds `r` to the end of `you`:

<img width="982" alt="image" src="https://github.com/user-attachments/assets/8065f5bd-0293-4d8a-b047-526d58912bbb" />

<img width="932" alt="image" src="https://github.com/user-attachments/assets/8b3223e8-7c36-4da8-b38b-f1570089ebbe" />


### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#<your-branch-name>
```

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged
