### PR TITLE
Override minimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,11 +65,13 @@
   "resolutions": {
     "@graphql-tools/url-loader": "8.0.16",
     "@graphql-codegen/client-preset": "4.7.0",
-    "@graphql-codegen/typescript-operations": "4.5.0"
+    "@graphql-codegen/typescript-operations": "4.5.0",
+    "minimatch": "9.0.5"
   },
   "overrides": {
     "@graphql-tools/url-loader": "8.0.16",
     "@graphql-codegen/client-preset": "4.7.0",
-    "@graphql-codegen/typescript-operations": "4.5.0"
+    "@graphql-codegen/typescript-operations": "4.5.0",
+    "minimatch": "9.0.5"
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?
![image](https://github.com/user-attachments/assets/ca2acd08-173b-4264-aca5-dfa919d26c6f)

Fixes support for Node 18


* In [this PR](https://github.com/graphql-hive/graphql-config/pull/1499) a transitive dependency dropped Node 18 in a patch.
* 

### WHAT is this pull request doing?

* This PR sets a override for a version that still supports Node 18

### Test this PR

```bash
nvm use 18
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#<your-branch-name>
```

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged
