### PR TITLE
Remove extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     "graphql.vscode-graphql",
-    "shopify.polaris-for-vscode",
-    "shopify.vscode-shopify-dev-assistant"
+    "shopify.polaris-for-vscode"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
     "graphql.vscode-graphql",
-    "shopify.polaris-for-vscode"
+    "shopify.polaris-for-vscode",
   ]
 }


### PR DESCRIPTION
### WHY are these changes introduced?

We added the dev assistant VSCode extension as a recommended extension on our remix app template. Since VSCode now have MCP support, that is our greenpath for developers building with Shopify.

### WHAT is this pull request doing?

Removing the dev assistant extension from the "recommended" extensions . 
