### PR TITLE
Remove local CLI dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @shopify/shopify-app-template-remix
 
+## 2025.06.12
+-[#1082](https://github.com/Shopify/shopify-app-template-remix/pull/1082) Remove local Shopify CLI from the template. Developers should use the Shopify CLI [installed globally](https://shopify.dev/docs/api/shopify-cli#installation).
 ## 2025.03.18
 -[#998](https://github.com/Shopify/shopify-app-template-remix/pull/998) Update to Vite 6
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@remix-run/react": "^2.16.1",
     "@remix-run/serve": "^2.16.1",
     "@shopify/app-bridge-react": "^4.1.6",
-    "@shopify/cli": "^3.63.1",
     "@shopify/polaris": "^12.0.0",
     "@shopify/shopify-app-remix": "^3.7.0",
     "@shopify/shopify-app-session-storage-prisma": "^6.0.0",


### PR DESCRIPTION
Developers should use the global CLI installation

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#remove-cli-dependency
```

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged
