### PR TITLE
Polaris docs 2025 tweaks

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -8,9 +8,7 @@ import {
   Scripts,
   ScrollRestoration,
   useLoaderData,
-  useNavigate,
 } from "@remix-run/react";
-import { useEffect } from "react";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   await authenticate.admin(request);
@@ -20,20 +18,6 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
 export default function App() {
   const { apiKey } = useLoaderData<typeof loader>();
-
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    const handleNavigate = (event: Event) => {
-      const href = (event.target as HTMLElement)?.getAttribute("href");
-      if (href) navigate(href);
-    };
-
-    document.addEventListener("shopify:navigate", handleNavigate);
-
-    return () =>
-      document.removeEventListener("shopify:navigate", handleNavigate);
-  }, [navigate]);
 
   return (
     <html>

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -156,33 +156,37 @@ export default function Index() {
             </s-button>
           )}
         </s-stack>
+        {fetcher.data?.product && (
+          <s-section heading="productCreate mutation">
+            <s-stack direction="column" gap="base">
+              <s-box
+                padding="base"
+                borderWidth="base"
+                borderRadius="base"
+                borderColor="auto"
+                background="subdued"
+              >
+                <pre style={{ margin: 0 }}>
+                  <code>{JSON.stringify(fetcher.data.product, null, 2)}</code>
+                </pre>
+              </s-box>
+
+              <s-heading>productVariantsBulkUpdate mutation</s-heading>
+              <s-box
+                padding="base"
+                borderWidth="base"
+                borderRadius="base"
+                borderColor="auto"
+                background="subdued"
+              >
+                <pre style={{ margin: 0 }}>
+                  <code>{JSON.stringify(fetcher.data.variant, null, 2)}</code>
+                </pre>
+              </s-box>
+            </s-stack>
+          </s-section>
+        )}
       </s-section>
-      {fetcher.data?.product && (
-        <s-section heading="productCreate mutation">
-          <s-paragraph>
-            {JSON.stringify(fetcher.data.product, null, 2)}
-          </s-paragraph>
-
-          <s-box
-            padding="base"
-            borderWidth="base"
-            borderRadius="base"
-            borderColor="auto"
-            background="subdued"
-          >
-            <pre style={{ margin: 0 }}>
-              <code>{JSON.stringify(fetcher.data.product, null, 2)}</code>
-            </pre>
-          </s-box>
-
-          <s-heading>productVariantsBulkUpdate mutation</s-heading>
-          <s-box>
-            <pre style={{ margin: 0 }}>
-              <code>{JSON.stringify(fetcher.data.variant, null, 2)}</code>
-            </pre>
-          </s-box>
-        </s-section>
-      )}
 
       <s-section slot="aside" heading="App template specs">
         <s-paragraph>

--- a/app/routes/auth.login/route.tsx
+++ b/app/routes/auth.login/route.tsx
@@ -27,22 +27,25 @@ export default function Auth() {
   const { errors } = actionData || loaderData;
 
   return (
-    <s-page>
-      <Form method="post">
-        <s-section heading="Log in">
-          <s-text-field
-            type="text"
-            name="shop"
-            label="Shop domain"
-            helpText="example.myshopify.com"
-            value={shop}
-            onChange={setShop}
-            autoComplete="on"
-            error={errors.shop}
-          ></s-text-field>
-          <s-button submit>Log in</s-button>
-        </s-section>
-      </Form>
-    </s-page>
+    <>
+      <script src="https://cdn.shopify.com/shopifycloud/app-bridge-ui-experimental.js"></script>
+      <s-page>
+        <Form method="post">
+          <s-section heading="Log in">
+            <s-text-field
+              type="text"
+              name="shop"
+              label="Shop domain"
+              helpText="example.myshopify.com"
+              value={shop}
+              onChange={setShop}
+              autoComplete="on"
+              error={errors.shop}
+            ></s-text-field>
+            <s-button submit>Log in</s-button>
+          </s-section>
+        </Form>
+      </s-page>
+    </>
   );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

1. Fixes an issue where App Bridge & App Bridge components are loaded on the marketing index page.  App Bridge especially should not be loaded on the marketing page, because it is not embedded
2. Fixes a layout/design issue with the index page:

Before:

<img width="655" alt="Screenshot 2025-06-19 at 11 25 35 AM" src="https://github.com/user-attachments/assets/620e3118-2ebb-47cc-9743-f5860ab93d18" />

After:

<img width="662" alt="Screenshot 2025-06-19 at 11 20 59 AM" src="https://github.com/user-attachments/assets/2e37df2d-1092-4818-abf5-ae533c15d4d7" />

### WHAT is this pull request doing?

1. Move App Bridge & Polaris web component into the app/ and login route rather than in root.tsx
2. Tweak design of the app index page

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#polaris-docs-2025-tweaks
```

### Checklist

N/A:

- ~~[ ] I have made changes to the `README.md` file and other related documentation, if applicable~~
- ~~[ ] I have added an entry to `CHANGELOG.md`~~
- ~~[ ] I'm aware I need to create a new release when this PR is merged~~
