### PR TITLE
Remove deprecated npm config values

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,2 @@
 engine-strict=true
-auto-install-peers=true
-shamefully-hoist=true
-enable-pre-post-scripts=true
+@shopify:registry=https://registry.npmjs.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # @shopify/shopify-app-template-remix
 
+## 2025.07.07
+- [#1103](https://github.com/Shopify/shopify-app-template-remix/pull/1086) Remove deprecated .npmrc config values
+
 ## 2025.06.12
 - [#1075](https://github.com/Shopify/shopify-app-template-remix/pull/1075) Add Shopify MCP to [VSCode configs](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_enable-mcp-support-in-vs-code)
 


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/Shopify/first-party-library-planning/issues/748
<img width="1149" alt="image" src="https://github.com/user-attachments/assets/c79a2eca-9473-4371-9ee6-96c888ddc917" />

When using Node 24 we were seeing various warnings about npm config values that are no longer necessary.

### WHAT is this pull request doing?

* Removes `auto-install-peers` - this one was briefly an npm config but deprecated
* Removes `enable-pre-post-scripts` This was added when this template used a `predev` script in the `package.json`, that script in now run from the shopify.web.toml
* Removes `shamefully-hoist=true` not necessary with our tooling


### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#resolve-npm-warnings
```

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [x] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged
