### PR TITLE
Use an explicit API version to configure graphqlrc

### DIFF
--- a/.graphqlrc.ts
+++ b/.graphqlrc.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import { LATEST_API_VERSION } from "@shopify/shopify-api";
+import { ApiVersion } from "@shopify/shopify-api";
 import { shopifyApiProject, ApiType } from "@shopify/api-codegen-preset";
 import type { IGraphQLConfig } from "graphql-config";
 
@@ -8,8 +8,11 @@ function getConfig() {
     projects: {
       default: shopifyApiProject({
         apiType: ApiType.Admin,
-        apiVersion: LATEST_API_VERSION,
-        documents: ["./app/**/*.{js,ts,jsx,tsx}", "./app/.server/**/*.{js,ts,jsx,tsx}"],
+        apiVersion: ApiVersion.July25,
+        documents: [
+          "./app/**/*.{js,ts,jsx,tsx}",
+          "./app/.server/**/*.{js,ts,jsx,tsx}",
+        ],
         outputDir: "./app/types",
       }),
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # @shopify/shopify-app-template-remix
 
+## 2025.08.16
+- [#52](https://github.com/Shopify/shopify-app-template-remix/pull/1153) Use `ApiVersion.July25` rather than `LATEST_API_VERSION` in `.graphqlrc`.
+
 ## 2025.07.07
 - [#1103](https://github.com/Shopify/shopify-app-template-remix/pull/1086) Remove deprecated .npmrc config values
 


### PR DESCRIPTION
### WHY are these changes introduced?

Previously we configured `.graphqlrc` with the Shopify's `LATEST_API_VERSION`.  This is problematic because using `LATEST_API_VERSION` can incure breaking changes at the API layer, without the developer explicitly opting into those changes.

### WHAT is this pull request doing?

We now set an explicit version, just as we do in shopify.server.ts`


### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#use-explicit-api-version
```

### Checklist

- ~~[ ] I have made changes to the `README.md` file and other related documentation, if applicable~~
- [x] I have added an entry to `CHANGELOG.md`
- ~~[ ] I'm aware I need to create a new release when this PR is merged~~
