### PR TITLE
Update to latest version of Shopify Packages && Drop Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [18, 20]
+        version: [20, 22, 24]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0

--- a/.github/workflows/convert-to-js.yml
+++ b/.github/workflows/convert-to-js.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 18.20.x
+          node-version: 20.10.x
           cache: 'yarn'
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/shopify-app-template-remix
 
+## 2025.09.17
+- [#1156](https://github.com/Shopify/shopify-app-template-remix/pull/1156) Update shopify-app-remix to v4.0.0 and shopify-app-session-storage-prisma to v7.0.0
+- Update minimum Node.js version to 20
+  - CI matrix now tests Node 20, 22, and 24 (previously 18, 20)
+  - Dockerfile updated to use node:20-alpine base image
+  - convert-to-js workflow updated to use Node 20.10.x
+
 ## 2025.07.07
 - [#1103](https://github.com/Shopify/shopify-app-template-remix/pull/1086) Remove deprecated .npmrc config values
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 RUN apk add --no-cache openssl
 
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -318,15 +318,6 @@ dev = "npm exec remix vite:dev"
 
 See the [Prisma documentation](https://www.prisma.io/docs/getting-started/setup-prisma/start-from-scratch/mongodb/connect-your-database-node-mongodb) for connecting to a MongoDB database.
 
-### I want to use Polaris v13.0.0 or higher
-
-Currently, this template is set up to work on node v18.20 or higher. However, `@shopify/polaris` is limited to v12 because v13 can only run on node v20+.
-
-You don't have to make any changes to the code in order to be able to upgrade Polaris to v13, but you'll need to do the following:
-
-- Upgrade your node version to v20.10 or higher.
-- Update your `Dockerfile` to pull `FROM node:20-alpine` instead of `node:18-alpine`
-
 ### "nbf" claim timestamp check failed
 
 This error will occur of the `nbf` claim timestamp check failed. This is because the JWT token is expired.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "type": "module",
   "engines": {
-    "node": "^18.20 || ^20.10 || >=21.0.0"
+    "node": "^20.10 || >=21.0.0"
   },
   "dependencies": {
     "@prisma/client": "^6.2.1",
@@ -31,8 +31,8 @@
     "@remix-run/serve": "^2.16.1",
     "@shopify/app-bridge-react": "^4.1.6",
     "@shopify/polaris": "^12.0.0",
-    "@shopify/shopify-app-remix": "^3.7.0",
-    "@shopify/shopify-app-session-storage-prisma": "^6.0.0",
+    "@shopify/shopify-app-remix": "^4.0.0",
+    "@shopify/shopify-app-session-storage-prisma": "^7.0.0",
     "isbot": "^5.1.0",
     "prisma": "^6.2.1",
     "react": "^18.2.0",


### PR DESCRIPTION
### WHAT is this pull request doing?
* Update shopify-app-remix to v4.0.0 and shopify-app-session-storage-prisma to v7.0.0
* Drops support for Node 18
* Updates all workflows to use Node 20
* Updates dockerfile to use Node 20

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#v4-shopify-app-remix
```

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged
