### PR TITLE
Pin esbuild-plugins-node-modules-polyfill to 1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@graphql-codegen/client-preset": "4.7.0",
     "@graphql-codegen/typescript-operations": "4.5.0",
     "minimatch": "9.0.5",
-    "vite": "^6.2.2"
+    "vite": "^6.2.2",
+    "esbuild-plugins-node-modules-polyfill": "1.7.1"
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Npm install fails when creating a new app from this template with the following error:
```
npm error code 127
npm error path /path/to/node_modules/esbuild-plugins-node-modules-polyfill
npm error command failed
npm error command sh -c husky .github/husky
npm error sh: husky: command not found
```

The problem is that `esbuild-plugins-node-modules-polyfill@1.8.0` was published yesterday with a broken postinstall script:

- v1.7.1: Published with `_postinstall` (underscore prefix, npm ignores it) ✅
- v1.8.0: Published with `postinstall` (no underscore, npm runs it) ❌

Dependency chain:
```
shopify-app-template-remix  └── @remix-run/dev        └── esbuild-plugins-node-modules-polyfill: "^1.6.0" → resolves to 1.8.0 (broken)
```

Related issue: https://github.com/imranbarbhuiya/esbuild-plugins-node-modules-polyfill/issues/352

### WHAT is this pull request doing?

Add an npm override to pin esbuild-plugins-node-modules-polyfill to 1.7.1 until the upstream package is fixed.

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-remix#pin-esbuild-plugins-node-modules-polyfill
```

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged
