### PR TITLE
Revert "Pin esbuild-plugins-node-modules-polyfill to 1.7.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "@graphql-codegen/client-preset": "4.7.0",
     "@graphql-codegen/typescript-operations": "4.5.0",
     "minimatch": "9.0.5",
-    "vite": "^6.2.2",
-    "esbuild-plugins-node-modules-polyfill": "1.7.1"
+    "vite": "^6.2.2"
   }
 }


### PR DESCRIPTION
Reverts Shopify/shopify-app-template-remix#1215

A new working [version of esbuild-plugins-node-modules-polyfill has been released](https://github.com/imranbarbhuiya/esbuild-plugins-node-modules-polyfill/issues/352#issuecomment-3768810664) (1.8.1), so we can remove the override.

### How to test

`shopify app init --template https://github.com/Shopify/shopify-app-template-remix#revert-1215-pin-esbuild-plugins-node-modules-polyfill`