### PR TITLE
Fix waiting-for-response issue cleanup workflow

### DIFF
--- a/.github/workflows/close-waiting-for-response-issues.yml
+++ b/.github/workflows/close-waiting-for-response-issues.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   issues: write
 
 jobs:

--- a/.github/workflows/close-waiting-for-response-issues.yml
+++ b/.github/workflows/close-waiting-for-response-issues.yml
@@ -3,18 +3,57 @@ on:
   schedule:
     - cron: "30 1 * * *"
   workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check-need-info:
     runs-on: ubuntu-latest
-    steps:
-      - name: close-issues
-        uses: actions-cool/issues-helper@45d75b6cf72bf4f254be6230cb887ad002702491 # v3.6.3
-        with:
-          actions: "close-issues"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: "Waiting for Response"
-          inactive-day: 14
-          body: |
-            We are closing this issue because we did not hear back regarding additional details we needed to resolve this issue. If the issue persists and you are able to provide the missing clarification we need, you can respond here or create a new issue.
+    env:
+      LABEL: Waiting for Response
+      INACTIVE_DAYS: "14"
+      CLOSE_MESSAGE: |
+        We are closing this issue because we did not hear back regarding additional details we needed to resolve this issue. If the issue persists and you are able to provide the missing clarification we need, you can respond here or create a new issue.
 
-            We appreciate your understanding as we try to manage our number of open issues.
+        We appreciate your understanding as we try to manage our number of open issues.
+    steps:
+      - name: Close inactive issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          cutoff="$(date -u -d "${INACTIVE_DAYS} days ago" +"%Y-%m-%dT%H:%M:%SZ")"
+          issues_file="${RUNNER_TEMP}/issues-to-close.tsv"
+
+          echo "Looking for open issues labeled '${LABEL}' with no updates since ${cutoff}."
+
+          gh api --paginate --method GET "repos/${GITHUB_REPOSITORY}/issues" \
+            -f state=open \
+            -f labels="${LABEL}" \
+            -f per_page=100 \
+            --jq ".[] | select(.pull_request | not) | select(.updated_at < \"${cutoff}\") | [.number, .updated_at] | @tsv" \
+            > "${issues_file}"
+
+          if [[ ! -s "${issues_file}" ]]; then
+            echo "No issues to close."
+            exit 0
+          fi
+
+          issue_count="$(wc -l < "${issues_file}" | tr -d ' ')"
+          echo "Closing ${issue_count} issue(s)."
+
+          while IFS=$'\t' read -r issue_number updated_at; do
+            echo "Closing #${issue_number} (last updated ${updated_at})."
+
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${issue_number}/comments" \
+              -f body="${CLOSE_MESSAGE}" \
+              > /dev/null
+
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/${issue_number}" \
+              -f state=closed \
+              -f state_reason=not_planned \
+              > /dev/null
+          done < "${issues_file}"

--- a/.github/workflows/close-waiting-for-response-issues.yml
+++ b/.github/workflows/close-waiting-for-response-issues.yml
@@ -5,55 +5,21 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
   issues: write
 
 jobs:
   check-need-info:
     runs-on: ubuntu-latest
-    env:
-      LABEL: Waiting for Response
-      INACTIVE_DAYS: "14"
-      CLOSE_MESSAGE: |
-        We are closing this issue because we did not hear back regarding additional details we needed to resolve this issue. If the issue persists and you are able to provide the missing clarification we need, you can respond here or create a new issue.
-
-        We appreciate your understanding as we try to manage our number of open issues.
     steps:
       - name: Close inactive issues
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
+        uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
+        with:
+          days-before-stale: -1
+          days-before-close: -1
+          days-before-issue-close: 14
+          stale-issue-label: "Waiting for Response"
+          remove-issue-stale-when-updated: false
+          close-issue-message: |
+            We are closing this issue because we did not hear back regarding additional details we needed to resolve this issue. If the issue persists and you are able to provide the missing clarification we need, you can respond here or create a new issue.
 
-          cutoff="$(date -u -d "${INACTIVE_DAYS} days ago" +"%Y-%m-%dT%H:%M:%SZ")"
-          issues_file="${RUNNER_TEMP}/issues-to-close.tsv"
-
-          echo "Looking for open issues labeled '${LABEL}' with no updates since ${cutoff}."
-
-          gh api --paginate --method GET "repos/${GITHUB_REPOSITORY}/issues" \
-            -f state=open \
-            -f labels="${LABEL}" \
-            -f per_page=100 \
-            --jq ".[] | select(.pull_request | not) | select(.updated_at < \"${cutoff}\") | [.number, .updated_at] | @tsv" \
-            > "${issues_file}"
-
-          if [[ ! -s "${issues_file}" ]]; then
-            echo "No issues to close."
-            exit 0
-          fi
-
-          issue_count="$(wc -l < "${issues_file}" | tr -d ' ')"
-          echo "Closing ${issue_count} issue(s)."
-
-          while IFS=$'\t' read -r issue_number updated_at; do
-            echo "Closing #${issue_number} (last updated ${updated_at})."
-
-            gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${issue_number}/comments" \
-              -f body="${CLOSE_MESSAGE}" \
-              > /dev/null
-
-            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/${issue_number}" \
-              -f state=closed \
-              -f state_reason=not_planned \
-              > /dev/null
-          done < "${issues_file}"
+            We appreciate your understanding as we try to manage our number of open issues.


### PR DESCRIPTION
## What changed

Replaces the disabled `actions-cool/issues-helper` dependency with GitHub's maintained [`actions/stale`](https://github.com/actions/stale) action, pinned to the v10.4.0 commit.

The workflow preserves the existing behavior:

- only issues already labeled `Waiting for Response` are treated as stale
- no issues or pull requests are automatically marked stale
- pull requests are never closed
- labeled issues are closed after 14 days without activity
- the existing closing comment is preserved
- issues are closed as `not_planned`, the `actions/stale` default and the reason used by the previous workflow

`remove-issue-stale-when-updated` is disabled here because the existing `Remove Waiting Labels` workflow remains responsible for removing `Waiting for Response` when someone comments.

The workflow explicitly grants `issues: write` for issue updates and `actions: write` so `actions/stale` can persist progress through the Actions Cache API.

## Why

The scheduled workflow has been failing before its job starts with:

```text
Prepare all required actions
Getting action download info
Error: Repository access blocked
```

The `actions-cool/issues-helper` repository has been disabled by GitHub Staff, so Actions can no longer download it even though the workflow pins a commit SHA. Using GitHub's maintained stale-issue action restores the workflow without introducing custom issue-management code.

## Testing

- Validated the workflow YAML with `yq`.
- Verified the pinned SHA resolves to the `actions/stale` v10.4.0 commit.
- Verified every configured input exists in the pinned action's `action.yml`.
- Confirmed the repository currently has no open `Waiting for Response` issues, so the next run should safely no-op.

