### PR TITLE
Add Shopify AI Toolkit guidance to app template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Shopify app development
+
+This app is scaffolded from a Shopify app template. See the README for framework-specific details.
+
+Use the [Shopify AI Toolkit](https://shopify.dev/docs/apps/build/ai-toolkit) for all Shopify API and platform work. If missing, install it in the agent host per that page (or `npx skills add Shopify/shopify-ai-toolkit` for skill-compatible hosts) — do not add tooling to this repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Related to https://github.com/shop/issues-develop/issues/22870

# PR title

Add Shopify AI Toolkit guidance to shopify-app-template-remix

# PR body

## Motivation

Agents in scaffolded Shopify apps do not reliably discover Shopify AI tooling. An always-on `AGENTS.md` makes the guidance available to agent hosts, while the relative `CLAUDE.md` symlink makes the same instructions discoverable by Claude Code.

The guidance points developers to the [Shopify AI Toolkit](https://shopify.dev/docs/apps/build/ai-toolkit) and intentionally stays minimal; detailed guidance belongs in the toolkit skills rather than in every scaffolded app.

## Branches

This change should land on `main`, `javascript`. Tier 1; deprecated but still supported.
